### PR TITLE
Add missing parentheses in provider_hart_package

### DIFF
--- a/libraries/provider_hart_package.rb
+++ b/libraries/provider_hart_package.rb
@@ -55,7 +55,7 @@ class Chef
         private
 
         def hab(*command)
-          shell_out_with_timeout!(a_to_s("hab", *command)
+          shell_out_with_timeout!(a_to_s("hab", *command))
         end
       end
     end


### PR DESCRIPTION
Fixes #1

(IMO the resource should be named `habitat_package`. `.hart` is an
implementation detail.)

Signed-off-by: Nathan L Smith <smith@chef.io>