### PR TITLE
habitat resource improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ Usage:
 ```ruby
 hab_install "install habitat"
 ```
+
+```ruby
+hab_package "core/redis"
+
+hab_package "core/redis" do
+  version "3.2.3"
+end
+
+hab_package "core/redis" do
+  version "3.2.3/20160920131015"
+end
+```

--- a/libraries/provider_hab_install.rb
+++ b/libraries/provider_hab_install.rb
@@ -43,7 +43,15 @@ class Chef
       private
 
       def hab_path
-        "/usr/local/bin/hab"
+        if platform_family?("mac_os_x")
+          "/usr/local/bin"
+        elsif platform_family?("windows")
+          Chef::Log.warn "Habitat installation on Windows is not yet supported by this cookbook."
+          Chef::Log.warn "The installation location on Windows will probably change in the future."
+          "C:/Program Files/Habitat/hab.exe"
+        else
+          "/bin/hab"
+        end
       end
 
       def do_install

--- a/test/fixtures/cookbooks/fake/recipes/package.rb
+++ b/test/fixtures/cookbooks/fake/recipes/package.rb
@@ -1,4 +1,11 @@
 include_recipe "::install"
-hab_package "lamont-granquist/ruby/2.2.5/20160719232453"
-hab_package "lamont-granquist/ruby/2.3.1"
-hab_package "lamont-granquist/ruby"
+
+hab_package "core/redis"
+
+hab_package "lamont-granquist/ruby" do
+  version "2.3.1"
+end
+
+hab_package "core/bundler" do
+  version "1.13.3/20161011123917"
+end


### PR DESCRIPTION
provider improvements

This commit introduces several improvements to the hab_package
provider, and one fix for the hab_install provider.

First, set the default hab_path to "/bin/hab" in the hab_install
provider. When the Habitat "install.sh" script runs, it uses "hab pkg
binlink" to put the hab binary in the $PATH, which is by default
"/bin/hab", not "/usr/local/bin/hab". This is idempotent but not
convergent, we don't need to rerun the install every time.

Next, improve the hab_package provider. This has several components to
it.
- Ensure we `use_inline_resources`
- Validate the package name doesn't contain the version/release
- Clarify the message about the remove action
- Fix package installation convergence
- Change the test cookbook to use different package names
## Ensure we use_inline_resources

We're using the updated custom resource DSL in this, so we need to
`use_inline_resources` so that we get the correct behavior.
## Validate the package name doesn't contain the version/release

It is not idiomatic chef recipe code to specify `package` resources
with the `version` as part of the name, despite that being passed as a
string to the underlying command-line tool. While it is possible for
Habitat users to do this:

```
hab pkg install core/redis/3.2.3
```

In Chef this conflates to overloading the package name and it makes
detecting the idempotence of the resource more difficult, if not
impossible. Thus, the ability to pass the version/release to the
package name is not supported, and we validate this by raising an
exception if it's not the case.

Use the following forms for specifying Habitat package resources:

``` ruby
hab_package "core/redis"

hab_package "core/redis" do
  version "3.2.3"
end

hab_package "core/redis" do
  version "3.2.3/20160920131015"
end
```

Note that when specifying only the version, and not the release, the
provider looks at the remote depot for a candidate version, and if the
installed release does not match, the package will be installed from
the remote depot. To ensure that a specific release is used, specify
it as part of the version per the last example above.
## Clarify the message about the remove action

The best way to handle removing a package is to add that functionality
in the `hab` CLI, rather than do something potentially dangerous in
this provider.
## Fix package installation convergence

Previously, the install action would reinstall packages every Chef run
because we weren't checking for the existence of the current resource.
In this commit, we have implemented `version_requirement_satisfied?`
to determine whether there is a current version installed and if it
matches the version specified in the new resource. Because the Habitat
packages have a "version" and a "release" that both combine to be a
valid version identifier, it can be tricky to determine reliably which
version is installed, so we do our best here by splitting the
identifier on `/`.
## Change the test cookbook to use different package names

Because we no longer accept versions or version/releases as part of
the package name, we need to use unique package names in order to
avoid resource cloning issues.
