### PR TITLE
Add hab_service resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,3 +12,5 @@ suites:
     run_list: test::install
   - name: package
     run_list: test::package
+  - name: service
+    run_list: test::service

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ hab_package "core/redis" do
   version "3.2.3/20160920131015"
 end
 ```
+
+```ruby
+hab_package "core/nginx"
+
+hab_service "core/nginx"
+```

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -23,6 +23,7 @@ class Chef
   class Provider
     class Package
       class Hart < Chef::Provider::Package
+
         use_inline_resources
         use_multipackage_api
 
@@ -86,6 +87,13 @@ class Chef
 
         private
 
+        def hab(*command)
+          shell_out_with_timeout!(a_to_s("hab", *command))
+        rescue  Errno::ENOENT
+          Chef::Log.fatal("'hab' binary not found, use the 'hab_install' resource to install it first")
+          raise
+        end
+
         def validate_name!(name)
           unless name.squeeze("/").count("/") < 2
             raise ArgumentError, "package name must be specified as 'origin/name', use the 'version' property to specify a version"
@@ -99,17 +107,6 @@ class Chef
             n = n[0..(n.rindex('/')-1)]
           end
           n
-        end
-
-        def hab(*command)
-          begin
-            shell_out_with_timeout!(a_to_s("hab", *command))
-          rescue Errno::ENOENT
-            Chef::Log.fatal("'hab' binary not found! Install habitat before attempting to")
-            Chef::Log.fatal("manage habitat resources! The 'hab_install' resource can be")
-            Chef::Log.fatal("used to handle installation.")
-            raise
-          end
         end
 
         def depot_package(name, version = nil)

--- a/libraries/provider_hab_service_systemd.rb
+++ b/libraries/provider_hab_service_systemd.rb
@@ -1,0 +1,86 @@
+# Copyright:: Copyright 2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/provider/service"
+
+class Chef
+  class Provider
+    class Service
+      class HabServiceSystemd < Chef::Provider::Service
+
+        use_inline_resources
+
+        provides :hab_service_systemd
+        provides :hab_service do |node|
+          Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
+        end
+
+        action :start do
+          declare_resource(:systemd_unit, "#{short_service_name}.service") do
+            content unit_content
+            action :create
+          end
+
+          declare_resource(:service, short_service_name) do
+            subscribes :restart, "systemd_unit[#{short_service_name}.service]"
+            action :start
+          end
+        end
+
+        action :stop do
+          declare_resource(:service, short_service_name) do
+            action :stop
+          end
+        end
+
+        action :enable do
+          declare_resource(:systemd_unit, "#{short_service_name}.service") do
+            content unit_content
+            action :create
+          end
+        end
+
+        def short_service_name
+          new_resource.service_name.split("/")[1]
+        end
+
+        def unit_content
+          return new_resource.unit_content if new_resource.unit_content
+          {
+            Unit: {
+              Description: short_service_name,
+              After: "network.target audit.service"
+            },
+              Service: {
+              Environment: new_resource.environment,
+              ExecStart: "/bin/hab start #{new_resource.service_name}",
+              Restart: "on-failure"
+            }
+          }
+        end
+
+        private
+
+        def hab(*command)
+          shell_out_with_systems_locale!(a_to_s("hab", *command))
+        rescue  Errno::ENOENT
+          Chef::Log.fatal("'hab' binary not found, use the 'hab_install' resource to install it first")
+          raise
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_hab_service_systemd.rb
+++ b/libraries/resource_hab_service_systemd.rb
@@ -1,0 +1,43 @@
+#
+# Copyright:: Copyright 2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/resource/service"
+
+class Chef
+  class Resource
+    class HabServiceSystemd < Chef::Resource::Service
+
+      resource_name :hab_service
+      provides :hab_service
+
+      property :unit_content, [String, Hash]
+      property :environment, String, default: lazy { "SSL_CERT_FILE=#{hab('pkg path core/cacerts').stdout.chomp}/ssl/cert.pem" }
+
+      default_action :start
+
+      private
+
+      def hab(*command)
+        shell_out_with_systems_locale!(a_to_s("hab", *command))
+      rescue  Errno::ENOENT
+        Chef::Log.fatal("'hab' binary not found, use the 'hab_install' resource to install it first")
+        raise
+      end
+
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,3 +12,6 @@ end
 
 source_url "https://github.com/chef-cookbooks/habitat" if respond_to?(:source_url)
 issues_url "https://github.com/chef-cookbooks/habitat/issues" if respond_to?(:issues_url)
+
+# we need chef 12.5 for custom resources, and 12.11 for systemd_unit
+chef_version ">= 12.11"

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -1,0 +1,13 @@
+include_recipe "::install"
+
+user 'hab'
+
+hab_package 'core/nginx'
+
+hab_service 'core/nginx'
+
+hab_package 'core/redis'
+
+hab_service 'core/redis' do
+  action :enable
+end


### PR DESCRIPTION
This commit adds a hab_service resource, which is a thinly veiled
wrapper around a minimal systemd_unit and service resource.

It also moves the hab helper to a new helpers file so we don't have to
repeat that everywhere.

Signed-off-by: Joshua Timberman <joshua@chef.io>