### PR TITLE
Add a default recipe

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -98,6 +98,8 @@ platforms:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which
 
 suites:
+  - name: default
+    run_list: test::default
   - name: install
     run_list: test::install
   - name: package

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,8 @@ platforms:
   - name: ubuntu-16.04
 
 suites:
+  - name: default
+    run_list: test::default
   - name: install
     run_list: test::install
   - name: package

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Resources are written in the style of Chef 12.5 [custom resources](https://docs.
 
 This cookbook has no external cookbook dependencies. It does not attempt to maintain backwards compatibility with previous Chef versions.
 
+## Recipes
+
+### default
+
+Installs Habitat on the system using `hab_install`.  If
+`node["habitat"]["package"]` is defined, it will install that package and set
+up that package as a service.
+
+#### Examples
+
+```ruby
+node.default["habitat"]["package"] = "core/redis"
+include_recipe "habitat"
+```
+
 ## Resources
 
 ### hab_install

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,17 @@
+# Copyright:: Copyright 2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default["habitat"]["package"] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,28 @@
+# Copyright:: Copyright 2016, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+user "hab"
+hab_install "install habitat"
+
+if node["habitat"]["package"]
+  hab_package node["habitat"]["package"]
+
+  hab_service node["habitat"]["package"]
+
+  hab_service node["habitat"]["package"] do
+    action :enable
+  end
+end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe "habitat::default" do
+  let!(:chef_runner) do
+    ChefSpec::ServerRunner.new(
+      platform: "ubuntu",
+      version: "16.04"
+    )
+  end
+
+  def chef_converge(package = nil)
+    chef_runner.node.normal["habitat"]["package"] = package
+    chef_runner
+  end
+
+  context "when attribute for package is set" do
+    cached(:chef_run) do
+      chef_converge(package = "core/redis").converge(described_recipe)
+    end
+
+    it "creates a hab user" do
+      expect(chef_run).to create_user("hab")
+    end
+
+    it "installs habitat" do
+      expect(chef_run).to install_hab_install("install habitat")
+    end
+
+    it "installs core/redis" do
+      expect(chef_run).to install_hab_package("core/redis")
+    end
+
+    it "starts the core/redis service" do
+      expect(chef_run).to start_hab_service("core/redis")
+    end
+
+    it "enables the core/redis service" do
+      expect(chef_run).to enable_hab_service("core/redis")
+    end
+  end
+
+  context "when attribute for package is not set" do
+    cached(:chef_run) do
+      chef_converge.converge(described_recipe)
+    end
+
+    it "creates a hab user" do
+      expect(chef_run).to create_user("hab")
+    end
+
+    it "installs habitat" do
+      expect(chef_run).to install_hab_install("install habitat")
+    end
+
+    it "does not install core/redis" do
+      expect(chef_run).not_to install_hab_package("core/redis")
+    end
+
+    it "does not start core/redis service" do
+      expect(chef_run).not_to start_hab_service("core/redis")
+    end
+
+    it "does not enable core/redis service" do
+      expect(chef_run).not_to enable_hab_service("core/redis")
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,0 +1,2 @@
+node.default["habitat"]["package"] = "core/redis"
+include_recipe "habitat"

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,16 @@
+describe user("hab") do
+  it { should exist }
+end
+
+describe directory("/hab/pkgs/core/redis") do
+  it { should exist }
+end
+
+describe file("/etc/systemd/system/redis.service") do
+  it { should exist }
+end
+
+describe systemd_service("redis") do
+  it { should_not be_running }
+  it { should be_enabled }
+end


### PR DESCRIPTION
This adds a `default` recipe so that users can choose to have a simple `role` that has `habitat` and if they choose can have application installed setup and ready to go.

Signed-off-by: Ben Dang <me@bdang.it>