### PR TITLE
Add a `depot_url` property to the `hab_install` resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This resource is written as a Chef 12.5 custom resource.
 #### Properties
 
 * `install_url`: URL to the install script, default is from the [habitat repo](https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh)
+* `depot_url`: Optional URL to an alternate Depot (defaults to the public Depot)
 * `version`: The version of habitat to install (defaults to latest)
 * `channel`: The release channel to install from (defaults to `stable`)
 
@@ -54,6 +55,12 @@ hab_install 'install habitat'
 ```ruby
 hab_install 'install habitat' do
   version "0.12.0"
+end
+```
+
+```ruby
+hab_install 'install habitat' do
+  depot_url "http://localhost/v1/depot"
 end
 ```
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,6 +21,7 @@ resource_name :hab_install
 provides :hab_install
 
 property :install_url, String, default: "https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh"
+property :depot_url, String
 property :version, String
 property :channel, String
 
@@ -38,6 +39,7 @@ action :install do
 
   execute "installing with hab-install.sh" do
     command hab_command
+    environment "HAB_DEPOT_URL" => new_resource.depot_url if new_resource.depot_url
   end
 end
 
@@ -48,6 +50,7 @@ action :upgrade do
 
   execute "installing with hab-install.sh" do
     command hab_command
+    environment "HAB_DEPOT_URL" => new_resource.depot_url if new_resource.depot_url
   end
 end
 

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -20,4 +20,11 @@ describe "test::install" do
         .with(version: "0.12.0")
     end
   end
+
+  context "when compiling the install recipe with a depot url" do
+    it "installs habitat" do
+      expect(chef_run).to install_hab_install("install habitat with depot url")
+        .with(depot_url: "https://localhost/v1/depot")
+    end
+  end
 end

--- a/test/fixtures/cookbooks/test/recipes/install.rb
+++ b/test/fixtures/cookbooks/test/recipes/install.rb
@@ -3,3 +3,7 @@ hab_install "install habitat"
 hab_install "install habitat with version" do
   version "0.12.0"
 end
+
+hab_install "install habitat with depot url" do
+  depot_url "https://localhost/v1/depot"
+end


### PR DESCRIPTION
This additional optional property allows a user to install the initial `core/hab` package from an alternate Depot (currently for Linux only).

![gif-keyboard-13858352337804158099](https://cloud.githubusercontent.com/assets/261548/22109706/274f4e8e-de59-11e6-982f-84396cdc1a27.gif)
