### PR TITLE
Add property for ExecStart options

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A future version of this resource may support other service providers.
 
 * `unit_content`: Content passed into the `systemd_unit` resource as its `content` property. By default this is a hash that starts the service with `/bin/hab start`.
 * `environment`: An environment string to pass into the unit file. By default this contains the location of the SSL certificate from the Habitat `core/cacerts` package.
+* `exec_start_options`: A `String` or `Array` of command line options to pass to `ExecStart` in the systemd unit.
 
 #### Examples
 
@@ -153,6 +154,17 @@ Environment = "HAB_MAPP=workers=3"
 ExecStart = "/bin/hab start myorigin/myapp"
 Restart = "on-failure"
 EOF
+end
+
+# ExecStart options as an array
+hab_service 'core/redis' do
+  exec_start_options ['--listen-gossip 9999', '--listen-http 9998']
+  action :enable
+end
+
+# ExecStart options as a string
+hab_service 'core/haproxy' do
+  exec_start_options '--permanent-peer'
 end
 ```
 

--- a/libraries/provider_hab_service_systemd.rb
+++ b/libraries/provider_hab_service_systemd.rb
@@ -63,8 +63,11 @@ class Chef
           new_resource.service_name.split("/")[1]
         end
 
-        def combine_exec_start_options
-          Array(new_resource.exec_start_options).join(" ")
+        def exec_start_command
+          ["/bin/hab start",
+            new_resource.service_name,
+            new_resource.exec_start_options].
+            flatten.compact.join(" ")
         end
 
         def unit_content
@@ -76,8 +79,7 @@ class Chef
             },
             Service: {
               Environment: new_resource.environment,
-              ExecStart: ["/bin/hab start #{new_resource.service_name}",
-                          combine_exec_start_options].join("\s"),
+              ExecStart: exec_start_command,
               Restart: "on-failure",
             },
           }

--- a/libraries/provider_hab_service_systemd.rb
+++ b/libraries/provider_hab_service_systemd.rb
@@ -63,6 +63,10 @@ class Chef
           new_resource.service_name.split("/")[1]
         end
 
+        def combine_exec_start_options
+          Array(new_resource.exec_start_options).join(" ")
+        end
+
         def unit_content
           return new_resource.unit_content if new_resource.unit_content
           {
@@ -72,7 +76,8 @@ class Chef
             },
             Service: {
               Environment: new_resource.environment,
-              ExecStart: "/bin/hab start #{new_resource.service_name}",
+              ExecStart: ["/bin/hab start #{new_resource.service_name}",
+                          combine_exec_start_options].join("\s"),
               Restart: "on-failure",
             },
           }

--- a/libraries/resource_hab_service_systemd.rb
+++ b/libraries/resource_hab_service_systemd.rb
@@ -25,6 +25,7 @@ class Chef
       provides :hab_service
 
       property :unit_content, [String, Hash]
+      property :exec_start_options, [String, Array]
       property :environment, String, default: lazy { "SSL_CERT_FILE=#{hab('pkg', 'path', 'core/cacerts').stdout.chomp}/ssl/cert.pem" }
 
       default_action :start

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "test::install" do
+describe "test::install_for_chefspec" do
   cached(:chef_run) do
     ChefSpec::ServerRunner.new(
       platform: "ubuntu",
@@ -8,21 +8,17 @@ describe "test::install" do
     ).converge(described_recipe)
   end
 
-  context "when compiling the install recipe" do
+  context "when compiling the install recipe for chefspec" do
     it "installs habitat" do
       expect(chef_run).to install_hab_install("install habitat")
     end
-  end
 
-  context "when compiling the install recipe with a version" do
-    it "installs habitat" do
+    it "installs habitat with a version" do
       expect(chef_run).to install_hab_install("install habitat with version")
         .with(version: "0.12.0")
     end
-  end
 
-  context "when compiling the install recipe with a depot url" do
-    it "installs habitat" do
+    it "installs habitat with a depot url" do
       expect(chef_run).to install_hab_install("install habitat with depot url")
         .with(depot_url: "https://localhost/v1/depot")
     end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -20,5 +20,17 @@ describe "test::service" do
     it "enables the core/redis service" do
       expect(chef_run).to enable_hab_service("core/redis")
     end
+
+    it "enables core/redis with an Array of ExecStart options" do
+      expect(chef_run).to enable_hab_service("core/redis").with(
+        exec_start_options: ["--listen-gossip 9999", "--listen-http 9998"]
+      )
+    end
+
+    it "takes ExecStart options for core/haproxy service" do
+      expect(chef_run).to start_hab_service("core/haproxy").with(
+        exec_start_options: "--permanent-peer"
+      )
+    end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/install.rb
+++ b/test/fixtures/cookbooks/test/recipes/install.rb
@@ -1,9 +1,1 @@
-hab_install "install habitat"
-
-hab_install "install habitat with version" do
-  version "0.12.0"
-end
-
-hab_install "install habitat with depot url" do
-  depot_url "https://localhost/v1/depot"
-end
+hab_install "latest"

--- a/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
+++ b/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
@@ -1,0 +1,11 @@
+# This recipe is used for running the `install_spec` tests, it should
+# not be used in the other recipes.
+hab_install "install habitat"
+
+hab_install "install habitat with version" do
+  version "0.12.0"
+end
+
+hab_install "install habitat with depot url" do
+  depot_url "https://localhost/v1/depot"
+end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -14,5 +14,14 @@ hab_package "core/redis" do
 end
 
 hab_service "core/redis" do
+  # Use an array of options!
+  exec_start_options ["--listen-gossip 9999", "--listen-http 9998"]
   action :enable
+end
+
+hab_package "core/haproxy"
+
+hab_service "core/haproxy" do
+  # Use a string of option [sic]
+  exec_start_options "--permanent-peer"
 end

--- a/test/integration/install/default_spec.rb
+++ b/test/integration/install/default_spec.rb
@@ -4,6 +4,6 @@ describe file("/bin/hab") do
 end
 
 describe command("hab -V") do
-  its("stdout") { should match(/^hab 0.12.0/) }
+  its("stdout") { should match(/^hab \d+\.\d+.\d+/) }
   its("exit_status") { should eq 0 }
 end

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -33,3 +33,8 @@ describe systemd_service("redis") do
   it { should_not be_running }
   it { should be_enabled }
 end
+
+describe file("/etc/systemd/system/haproxy.service") do
+  it { should exist }
+  its(:content) { should match(%r{^ExecStart = /bin/hab start core/haproxy --permanent-peer$}) }
+end


### PR DESCRIPTION
In some cases, it is desirable to change only the ExecStart parameter from the default value. Before this commit, one would have to write all the unit content out. With this, options can be passed in using an array or a string. If the property is a string, it gets Array()'d.

Signed-off-by: Joshua Timberman <joshua@chef.io>