### PR TITLE
Simplify Chef::Provider::Package::Hart#current_versions.

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -134,7 +134,7 @@ class Chef
         end
 
         def current_versions
-          package_name_array.zip(new_version_array).map do |n, _v|
+          package_name_array.map do |n|
             installed_version(n)
           end
         end


### PR DESCRIPTION
While doing some code spelunking we found a method that wasn't immediately obvious to us, and it looks like it is doing some extra stuff that isn't necessary. Since this is ignoring the second argument in the map, doing the zip isn't needed:

```
irb(main):004:0> [1,2,3].zip([4,5,6])
=> [[1, 4], [2, 5], [3, 6]]
irb(main):005:0> [1,2,3].zip([4,5,6]).map {|x, _| x }
=> [1, 2, 3]
```

Signed-off-by: Pete Higgins <pete@peterhiggins.org>