### PR TITLE
Fix the data structure we use to determine if a service is running

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -44,7 +44,7 @@ load_current_value do
   end
 
   running begin
-            sup_for_service_name['supervisor']['state'] == 'Up'
+            sup_for_service_name['process']['state'] == 'Up'
           rescue
             false
           end


### PR DESCRIPTION
The data returned by services has changed. This results in us always thinking a service was in a stopped state. When we went to actually stop it we didn't do anything as it appeared to already be stopped. Oops

Signed-off-by: Tim Smith <tsmith@chef.io>