### PR TITLE
Add hab_version and hab_channel to the sup service

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -16,81 +16,65 @@ verifier:
 platforms:
 - name: amazonlinux
   driver:
-    image: amazonlinux:latest
+    image: dokken/amazonlinux
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install lsof which initscripts net-tools sudo wget
 
 - name: debian-7
   driver:
-    image: debian:7
+    image: dokken/debian-7
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-      - RUN rm -rf /sbin/initctl
 
 - name: debian-8
   driver:
-    image: debian:8
+    image: dokken/debian-8
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
 - name: debian-9
   driver:
-    image: debian:9
+    image: dokken/debian-9
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools systemd -y
 
 - name: centos-6
   driver:
-    image: centos:6
+    image: dokken/centos-6
     platform: rhel
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install lsof which initscripts net-tools wget net-tools
 
 - name: centos-7
   driver:
-    image: centos:7
+    image: dokken/centos-7
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
 
 - name: fedora-latest
   driver:
-    image: fedora:latest
+    image: dokken/fedora-latest
     pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install which systemd-sysv initscripts wget net-tools
 
 - name: ubuntu-14.04
   driver:
-    image: ubuntu-upstart:14.04
+    image: dokken/ubuntu-14.04
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
 - name: ubuntu-16.04
   driver:
-    image: ubuntu:16.04
+    image: dokken/ubuntu-16.04
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
 - name: opensuse-leap
   driver:
-    image: opensuse:leap
+    image: dokken/opensuse-leap
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools systemd-sysvinit
 
 suites:
   - name: install

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,16 +9,16 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazon-linux
+  - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
-  - name: centos-6.9
-  - name: centos-7.3
-  - name: debian-7.11
-  - name: debian-8.8
-  - name: debian-9.0
-  - name: fedora-25
-  - name: opensuse-leap-42.2
+  - name: centos-6
+  - name: centos-7
+  - name: debian-7
+  - name: debian-8
+  - name: debian-9
+  - name: fedora-26
+  - name: opensuse-leap-42
   - name: ubuntu-14.04
   - name: ubuntu-16.04
 
@@ -31,13 +31,13 @@ suites:
     run_list: test::service
     # these platforms don't have systemd as the default init system
     excludes:
-      - centos-6.9
-      - debian-7.11
+      - centos-6
+      - debian-7
       - ubuntu-14.04
   - name: sup
     run_list: test::sup
     # these platforms don't have systemd as the default init system
     excludes:
-      - centos-6.9
-      - debian-7.11
+      - centos-6
+      - debian-7
       - ubuntu-14.04

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 - `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
 - `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
+- `hab_version`: The version of Habitat to install. Defaults to latest
+- `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
 
 #### Examples

--- a/chefignore
+++ b/chefignore
@@ -92,7 +92,6 @@ Policyfile.lock.json
 CONTRIBUTING*
 CHANGELOG*
 TESTING*
-MAINTAINERS.toml
 
 # Strainer #
 ############

--- a/resources/sup_systemd.rb
+++ b/resources/sup_systemd.rb
@@ -29,9 +29,15 @@ property :override_name, String, default: 'default'
 property :org, String, default: 'default'
 property :peer, String
 property :ring, String
+property :hab_version, String
+property :hab_channel, String
 
 action :run do
-  hab_install new_resource.name
+  hab_install new_resource.name do
+    version new_resource.hab_version if new_resource.hab_version
+    channel new_resource.hab_channel if new_resource.hab_channel
+  end
+
   hab_package 'core/hab-sup'
 
   systemd_unit "hab-sup-#{new_resource.override_name}.service" do

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -1,5 +1,7 @@
-include_recipe '::install'
-hab_sup 'default'
+hab_sup 'default' do
+  hab_version '0.26.1'
+  hab_channel 'stable'
+end
 
 user 'hab'
 group 'hab'


### PR DESCRIPTION
This allows controlling the version of habitat that is installed for your service

Signed-off-by: Tim Smith <tsmith@chef.io>