### PR TITLE
Bug Fix: Pull latest version from given channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the habitat cookbook.
 
+## 0.26.1 (2017-07-21)
+
+- `hab_package` now properly selects latest version from the specified channel.
+
 ## 0.26.0 (2017-07-17)
 
 ### Breaking Changes
@@ -12,7 +16,7 @@ This cookbook was updated to be compatible with the changes made in Habitat 0.26
 
 ### Other Changes
   - Resolves deprecation warnings introduced in Chef 13.2
-  - Removed references in the readme to Chefstyle and simplified some of the requirements information 
+  - Removed references in the readme to Chefstyle and simplified some of the requirements information
   - Added maintainer information to the readme and removed the maintainers file
 
 ## v0.4.0 (2017-04-26)

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -108,9 +108,10 @@ class Chef
           @depot_package ||= {}
           @depot_package[name] ||=
             begin
-              name_version = [name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
-              url = "#{new_resource.depot_url.chomp('/')}/pkgs/#{name_version}"
-              url << '/latest' unless name_version.count('/') >= 3
+              origin, pkg_name = name.split('/')
+              name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
+              url = "#{new_resource.depot_url.chomp('/')}/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
+              url << '/latest' unless name_version.count('/') >= 2
               Chef::JSONCompat.parse(http.get(url))
             rescue Net::HTTPServerException
               nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related cookbooks for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.26.0'
+version '0.26.1'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -8,6 +8,7 @@ hab_package 'lamont-granquist/ruby' do
 end
 
 hab_package 'core/bundler' do
+  channel 'unstable'
   version '1.13.3/20161011123917'
 end
 


### PR DESCRIPTION
Use the new `channels/` API to pull the latest version from the configured channel.

Signed-off-by: Tom Duffield <tom@chef.io>