### PR TITLE
Support multiple binds with hab_service

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -30,7 +30,7 @@ property :ring, String
 property :strategy, String
 property :topology, String
 property :depot_url, String
-property :bind, String
+property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
 property :service_group, String
 property :config_from, String
 property :override_name, String, default: 'default'
@@ -89,14 +89,14 @@ action_class do
     # certain options are only valid for specific `hab sup` subcommands.
     case action
     when :load
-      opts << "--bind #{new_resource.bind}" if new_resource.bind
+      opts.push(*new_resource.bind.map{|b| "--bind #{b}"}) if new_resource.bind
       opts << "--url #{new_resource.depot_url}" if new_resource.depot_url
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
     when :start
       opts << '--permanent-peer' if new_resource.permanent_peer
-      opts << "--bind #{new_resource.bind}" if new_resource.bind
+      opts.push(*new_resource.bind.map{|b| "--bind #{b}"}) if new_resource.bind
       opts << "--config-from #{new_resource.config_from}" if new_resource.config_from
       opts << "--url #{new_resource.depot_url}" if new_resource.depot_url
       opts << "--group #{new_resource.service_group}" if new_resource.service_group

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -52,3 +52,12 @@ end
 # memcached
 hab_package 'core/memcached'
 hab_service 'core/memcached'
+
+# Test binds
+hab_package 'core/ruby-rails-sample'
+hab_service 'core/ruby-rails-sample' do
+  bind [
+    'database:postgresql.default',
+    'fakething:otherthing.default'
+  ]
+end

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -23,3 +23,8 @@ describe file('/hab/sup/default/specs/memcached.spec') do
   it { should exist }
   its(:content) { should match(/^desired_state = "up"$/) }
 end
+
+describe file('/hab/sup/default/specs/ruby-rails-sample.spec') do
+  it { should exist }
+  its(:content) { should match(/binds = \["database:postgresql.default", "fakething:otherthing.default"\]/) }
+end


### PR DESCRIPTION
### Description

This allows the bind option to take an array as well as a string, and will pass `--bind` multiple times on the command line, allowing you to start habitat services that have multiple binds.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
