### PR TITLE
Add channel support to sup load/start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Manages a Habitat application service using `hab sup`/`hab service`. This requir
 - `service_group`: Only valid for `:start` or `:load` actions, passes `--group` with the specified service group to the hab command
 - `config_from`: Only valid for `:start` action, passes `--config-from` with the specified directory to the hab command
 - `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
+- `channel`: Only valid for `:start` or `:load` actions, passes `--channel` with the specified channel to the hab command
 
 #### Examples
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -34,6 +34,7 @@ property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
 property :service_group, String
 property :config_from, String
 property :override_name, String, default: 'default'
+property :channel, [Symbol, String], equal_to: [:unstable, 'unstable', :current, 'current', :stable, 'stable'], default: :stable
 
 load_current_value do
   http_uri = listen_http ? listen_http : 'http://localhost:9631'
@@ -94,6 +95,7 @@ action_class do
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
+      opts << "--channel #{new_resource.channel}"
     when :start
       opts << '--permanent-peer' if new_resource.permanent_peer
       opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
@@ -107,6 +109,7 @@ action_class do
       opts << "--ring #{new_resource.ring}" if new_resource.ring
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
+      opts << "--channel #{new_resource.channel}"
     end
 
     opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -28,7 +28,8 @@ describe 'test::service' do
     it 'loads a service with options' do
       expect(chef_run).to load_hab_service('core/redis').with(
         strategy: 'rolling',
-        topology: 'standalone'
+        topology: 'standalone',
+        channel: :stable
       )
     end
   end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -32,6 +32,7 @@ end
 hab_service 'core/redis' do
   strategy 'rolling'
   topology 'standalone'
+  channel :stable
   action [:load, :start]
 end
 

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -17,6 +17,7 @@ end
 describe file('/hab/sup/default/specs/redis.spec') do
   it { should exist }
   its(:content) { should match(/desired_state = "down"/) }
+  its(:content) { should match(/channel = "stable"/) }
 end
 
 describe file('/hab/sup/default/specs/memcached.spec') do


### PR DESCRIPTION
### Description

This allows users to specify which channel to use when loading or starting a service.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
