### PR TITLE
Add a hab_config resource

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -95,3 +95,10 @@ suites:
       - debian-7
       - centos-6
       - ubuntu-14.04
+  - name: config
+    run_list: test::config
+    # these platforms don't have systemd as the default init system
+    excludes:
+      - centos-6.9
+      - debian-7.11
+      - ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,3 +41,10 @@ suites:
       - centos-6
       - debian-7
       - ubuntu-14.04
+  - name: config
+    run_list: test::config
+    # these platforms don't have systemd as the default init system
+    excludes:
+      - centos-6.9
+      - debian-7.11
+      - ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
   - INSTANCE=package-centos-7
   - INSTANCE=service-ubuntu-1604
   - INSTANCE=service-centos-7
+  - INSTANCE=config-ubuntu-1604
+  - INSTANCE=config-centos-7
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/README.md
+++ b/README.md
@@ -188,6 +188,48 @@ hab_sup 'test-options' do
 end
 ```
 
+### hab_config
+
+Applies a given configuration to a habitat service using `hab config apply`.
+
+#### Actions
+
+- `apply`: (default action) apply the given configuration
+
+#### Properties
+
+- `service_group`: The service group to apply the configuration to, for
+  example, `nginx.default`
+- `config`: The configuration to apply as a ruby hash, for example,
+  `{ worker_count: 2, http: { keepalive_timeout: 120 } }`
+- `org`: (optional) passes the `--org` option with the specified org name
+  to the hab config command.
+- `peer`: (optional) passes the `--peer` option with the specified peer to the
+  hab config command.
+- `ring`: (optional) passes the `--ring` option with the specified ring key
+  name to the hab config command.
+- `api_host`: Hostname for the habitat api in order to look up the existing
+  configuration. Defaults to `127.0.0.1`.
+- `api_port`: Port number for the habitat api. Defaults to `9631`.
+
+#### Notes
+
+The version number of the configuration is automatically generated and will be
+the current timestamp in seconds since 1970-01-01 00:00:00 UTC.
+
+#### Examples
+
+```ruby
+hab_config "nginx.default" do
+  config({
+    worker_count: 2,
+    http: {
+      keepalive_timeout: 120
+    }
+  })
+end
+```
+
 ## Maintainers
 
 This cookbook is maintained by Chef's Community Cookbook Engineering team along with the following maintainers:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.34.1'
+version '0.34.2'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os
@@ -13,5 +13,6 @@ end
 source_url 'https://github.com/chef-cookbooks/habitat'
 issues_url 'https://github.com/chef-cookbooks/habitat/issues'
 
-# we need chef 12.5 for custom resources, and 12.11 for systemd_unit
-chef_version '>= 12.11'
+chef_version '>= 12.20.3'
+
+gem 'toml'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,0 +1,68 @@
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'toml'
+require 'net/http'
+require 'json'
+
+resource_name :hab_config
+
+property :config, Mash,
+         required: true,
+         coerce: proc { |m| m.is_a?(Hash) ? Mash.new(m) : m }
+property :service_group, String, name_property: true, desired_state: false
+property :peer, String, desired_state: false
+property :org, String, desired_state: false
+property :ring, String, desired_state: false
+property :api_host, String, default: '127.0.0.1', desired_state: false
+property :api_port, Integer, default: 9631, desired_state: false
+
+load_current_value do
+  uri = URI("http://#{api_host}:#{api_port}/census")
+  begin
+    census = Mash.new(JSON.parse(Net::HTTP.get(uri)))
+    sc = census['census_groups'][service_group]['service_config']['value']
+  rescue
+    # Default to a blank config if anything (http error, json parsing, finding
+    # the config object) goes wrong
+    sc = {}
+  end
+  config sc
+end
+
+action :apply do
+  converge_if_changed do
+    # Use the current timestamp as the serial number/incarnation
+    incarnation = Time.now.tv_sec
+
+    opts = []
+    # opts gets flattened by shell_out_compact later
+    opts << ['--peer', new_resource.peer] if new_resource.peer
+    opts << ['--org', new_resource.org] if new_resource.org
+    opts << ['--ring', new_resource.ring] if new_resource.ring
+
+    tempfile = Tempfile.new(['hab_config', '.toml'])
+    begin
+      tempfile.write(TOML::Generator.new(new_resource.config).body)
+      tempfile.close
+      shell_out_compact!(['hab', 'config', 'apply', opts,
+                          new_resource.service_group, incarnation,
+                          tempfile.path])
+    ensure
+      tempfile.close
+      tempfile.unlink
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/config.rb
+++ b/test/fixtures/cookbooks/test/recipes/config.rb
@@ -1,0 +1,38 @@
+include_recipe '::install'
+hab_sup 'default'
+
+user 'hab'
+group 'hab'
+
+hab_package 'core/nginx'
+hab_service 'core/nginx'
+
+# we need to sleep to let the nginx service have enough time to
+# startup properly before we can configure it.
+# This is here due to https://github.com/habitat-sh/habitat/issues/3155 and
+# can be removed if that issue is fixed.
+ruby_block 'wait-for-nginx-startup' do
+  block do
+    sleep 3
+  end
+  action :nothing
+  subscribes :run, 'hab_service[core/nginx]', :immediately
+end
+
+hab_config 'nginx.default' do
+  config(
+    worker_processes: 2,
+    http: {
+      keepalive_timeout: 120,
+    }
+  )
+end
+
+# Allow some time for the config to apply before running tests
+ruby_block 'wait-for-nginx-config' do
+  block do
+    sleep 3
+  end
+  action :nothing
+  subscribes :run, 'hab_config[nginx.default]', :immediately
+end

--- a/test/integration/config/default_spec.rb
+++ b/test/integration/config/default_spec.rb
@@ -1,0 +1,8 @@
+describe json('/hab/sup/default/data/census.dat') do
+  scpath = ['census_groups', 'nginx.default', 'service_config']
+  # Incarnation is just the current timestamp, so we can't compare to an exact
+  # value. Instead just make sure it looks right.
+  its(scpath + ['incarnation']) { should be > 1_500_000_000 }
+  its(scpath + %w(value worker_processes)) { should eq 2 }
+  its(scpath + %w(value http keepalive_timeout)) { should eq 120 }
+end


### PR DESCRIPTION
### Description

This change adds a new resource, hab_config, which will run `hab config apply` with the configuration in the resource.

### Issues Resolved

This is possibly related to #33, although it's not exactly the same (that feature request is for updating the configuration of a service on startup).

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
