### PR TITLE
Fix for hab 0.33.2 - do not provide '/v1/depot' to Hab URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the habitat cookbook.
 
+## 0.29.0 (2017-09-25)
+
+- Fix to account for [habitat-sh/habitat#3239](https://github.com/habitat-sh/habitat/pull/3239) - do not provide `/v1/depot` to Depot URL.
+
 ## 0.28.0 (2017-09-19)
 
 - Add channel support to sup load/start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 This file is used to list changes made in each version of the habitat cookbook.
 
-## 0.29.0 (2017-09-25)
+## 0.33.0 (2017-09-25)
 
 - Fix to account for [habitat-sh/habitat#3239](https://github.com/habitat-sh/habitat/pull/3239) - do not provide `/v1/depot` to Depot URL.
+- Pin the version of this cookbook along with the version of Habitat we install. This should match minor, but not necessarily patch versions.
 
 ## 0.28.0 (2017-09-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the habitat cookbook.
 
 ## 0.33.0 (2017-09-25)
 
+**Breaking change**
+
+This version is a compatibility change. All users of this cookbook must upgrade the cookbook to use current versions of Habitat.
+
 - Fix to account for [habitat-sh/habitat#3239](https://github.com/habitat-sh/habitat/pull/3239) - do not provide `/v1/depot` to Depot URL.
 - Pin the version of this cookbook along with the version of Habitat we install. This should match minor, but not necessarily patch versions.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 ### Habitat
 
-- 0.26+ (for channel support)
+- 0.33.2
+
+This cookbook installs a specific version of Habitat by default, as the upstream project is still pre-1.0 and APIs or similar behavior can change. When new versions of Habitat are released, the version should be updated:
+
+- `README.md`: note required version in this file
+- `resources/install.rb`: set the default to the new version
+- `spec/unit/install_spec`: to match the version from the resource
+- `test/integration/install/default_spec.rb`: to match the version from the resource
+
+Additionally, new versions must be tested that all behavior in the cookbook still works, otherwise the cookbook must be updated to match the behavior in the new version of Habitat.
 
 ### Chef
 
@@ -43,7 +52,7 @@ Installs Habitat on the system using the [install script](https://raw.githubuser
 
 - `install_url`: URL to the install script, default is from the [habitat repo](https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh)
 - `depot_url`: Optional URL to an alternate Depot (defaults to the public Depot)
-- `version`: The version of habitat to install (defaults to latest)
+- `version`: The version of habitat to install (defaults to `0.33.2`, see Requirements/Habitat above)
 - `channel`: The release channel to install from (defaults to `stable`)
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 - 0.33.2
 
-This cookbook installs a specific version of Habitat by default, as the upstream project is still pre-1.0 and APIs or similar behavior can change. When new versions of Habitat are released, the version should be updated:
+This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself.
+When new versions of Habitat are released, the version should be updated in these files:
 
 - `README.md`: note required version in this file
 - `resources/install.rb`: set the default to the new version
@@ -51,8 +52,7 @@ Installs Habitat on the system using the [install script](https://raw.githubuser
 #### Properties
 
 - `install_url`: URL to the install script, default is from the [habitat repo](https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh)
-- `depot_url`: Optional URL to an alternate Depot (defaults to the public Depot)
-- `version`: The version of habitat to install (defaults to `0.33.2`, see Requirements/Habitat above)
+- `bldr_url`: Optional URL to an alternate Builder (defaults to the public Builder)
 - `channel`: The release channel to install from (defaults to `stable`)
 
 #### Examples
@@ -63,13 +63,7 @@ hab_install 'install habitat'
 
 ```ruby
 hab_install 'install habitat' do
-  version "0.12.0"
-end
-```
-
-```ruby
-hab_install 'install habitat' do
-  depot_url "http://localhost/v1/depot"
+  bldr_url "http://localhost"
 end
 ```
 
@@ -88,7 +82,7 @@ This resource is written as a library resource because it subclasses Chef's `pac
 
 - `package_name`: A Habitat package name, must include the origin and package name separated by `/`, for example, `core/redis`
 - `version`: A Habitat version which contains the version and optionally a release separated by `/`, for example, `3.2.3` or `3.2.3/20160920131015`
-- `depot_url`: The habitat depot url where packages will be downloaded from (defaults to public habitat depot)
+- `bldr_url`: The habitat builder url where packages will be downloaded from (defaults to public habitat builder)
 - `channel`: The release channel to install from (defaults to `stable`)
 
 While it is valid to pass the version and release with a Habitat package as a "fully qualified package identifier" when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
@@ -132,7 +126,7 @@ Manages a Habitat application service using `hab sup`/`hab service`. This requir
 - `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
 - `strategy`: Only valid for `:start` or `:load` actions, passes `--strategy` with the specified update strategy to the hab command
 - `topology`: Only valid for `:start` or `:load` actions, passes `--topology` with the specified service topology to the hab command
-- `depot_url`: Only valid for `:start` or `:load` actions, passes `--url` with the specified Depot URL to the hab command
+- `bldr_url`: Only valid for `:start` or `:load` actions, passes `--url` with the specified Builder URL to the hab command
 - `bind`: Only valid for `:start` or `:load` actions, passes `--bind` with the specified services to bind to the hab command
 - `service_group`: Only valid for `:start` or `:load` actions, passes `--group` with the specified service group to the hab command
 - `config_from`: Only valid for `:start` action, passes `--config-from` with the specified directory to the hab command

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 - 0.33.2
 
-This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself.
-When new versions of Habitat are released, the version should be updated in these files:
+This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself. When new versions of Habitat are released, the version should be updated in these files:
 
 - `README.md`: note required version in this file
 - `resources/install.rb`: set the default to the new version
-- `spec/unit/install_spec`: to match the version from the resource
 - `test/integration/install/default_spec.rb`: to match the version from the resource
 
 Additionally, new versions must be tested that all behavior in the cookbook still works, otherwise the cookbook must be updated to match the behavior in the new version of Habitat.
+
+Users who wish to install a specific version of Habitat should use an older (0.28 or earlier) release of this cookbook, but note that is unsupported and they are advised to upgrade ASAP.
 
 ### Chef
 
@@ -170,7 +170,6 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 - `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
 - `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
-- `hab_version`: The version of Habitat to install. Defaults to latest
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
 

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -63,7 +63,7 @@ class Chef
 
         def install_package(names, versions)
           names.zip(versions).map do |n, v|
-            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.depot_url, "#{strip_version(n)}/#{v}")
+            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url, "#{strip_version(n)}/#{v}")
           end
         end
 
@@ -110,7 +110,7 @@ class Chef
             begin
               origin, pkg_name = name.split('/')
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
-              url = "#{new_resource.depot_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
+              url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
               Chef::JSONCompat.parse(http.get(url))
             rescue Net::HTTPServerException

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -110,7 +110,7 @@ class Chef
             begin
               origin, pkg_name = name.split('/')
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
-              url = "#{new_resource.depot_url.chomp('/')}/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
+              url = "#{new_resource.depot_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
               Chef::JSONCompat.parse(http.get(url))
             rescue Net::HTTPServerException

--- a/libraries/resource_hab_package.rb
+++ b/libraries/resource_hab_package.rb
@@ -24,7 +24,7 @@ class Chef
       resource_name :hab_package
       provides :hab_package
 
-      property :depot_url, String, regex: /.*/, default: 'https://willem.habitat.sh/v1/depot'
+      property :depot_url, String, regex: /.*/, default: 'https://willem.habitat.sh'
       property :channel, String, default: 'stable'
     end
   end

--- a/libraries/resource_hab_package.rb
+++ b/libraries/resource_hab_package.rb
@@ -24,7 +24,7 @@ class Chef
       resource_name :hab_package
       provides :hab_package
 
-      property :depot_url, String, regex: /.*/, default: 'https://willem.habitat.sh'
+      property :bldr_url, String, regex: /.*/, default: 'https://willem.habitat.sh'
       property :channel, String, default: 'stable'
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related cookbooks for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.29.0'
+version '0.33.0'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related cookbooks for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.28.0'
+version '0.29.0'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'habitat'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
-description 'Habitat related cookbooks for chef-client'
+description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.33.0'
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,7 +21,12 @@ resource_name :hab_install
 
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
 property :depot_url, String
-property :version, String
+
+# Default the installation version to one that we know the rest of
+# this cookbook will work with. This must be updated along with any
+# relevant code updates when new versions of Habitat are released.
+
+property :version, String, default: '0.33.2'
 property :channel, String
 
 action :install do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,9 +21,16 @@ resource_name :hab_install
 
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
 property :bldr_url, String
+property :version, String
 property :channel, String
 
 action :install do
+  if new_resource.version
+    Chef::Log.warn("Do not specify a version of Habitat with the 'hab_install' resource.")
+    Chef::Log.warn("The version property of the 'hab_install' resource will be removed in a future version.")
+    Chef::Log.warn("See https://github.com/chef-cookbooks/habitat/blob/master/README.md#habitat")
+  end
+
   if ::File.exist?(hab_path)
     cmd = shell_out!([hab_path, '--version', '0.33.2'])
     version = %r{hab (\d*\.\d*\.\d[^\/]*)}.match(cmd.stdout)[1]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -20,21 +20,14 @@
 resource_name :hab_install
 
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
-property :depot_url, String
-
-# Default the installation version to one that we know the rest of
-# this cookbook will work with. This must be updated along with any
-# relevant code updates when new versions of Habitat are released.
-
-property :version, String, default: '0.33.2'
+property :bldr_url, String
 property :channel, String
 
 action :install do
   if ::File.exist?(hab_path)
-    return unless new_resource.version
-    cmd = shell_out!([hab_path, '--version'])
+    cmd = shell_out!([hab_path, '--version', '0.33.2'])
     version = %r{hab (\d*\.\d*\.\d[^\/]*)}.match(cmd.stdout)[1]
-    return if new_resource.version == version
+    return if version == '0.33.2'
   end
 
   remote_file ::File.join(Chef::Config[:file_cache_path], 'hab-install.sh') do
@@ -43,7 +36,7 @@ action :install do
 
   execute 'installing with hab-install.sh' do
     command hab_command
-    environment 'HAB_DEPOT_URL' => new_resource.depot_url if new_resource.depot_url
+    environment 'HAB_BLDR_URL' => new_resource.bldr_url if new_resource.bldr_url
   end
 end
 
@@ -54,7 +47,7 @@ action :upgrade do
 
   execute 'installing with hab-install.sh' do
     command hab_command
-    environment 'HAB_DEPOT_URL' => new_resource.depot_url if new_resource.depot_url
+    environment 'HAB_BLDR_URL' => new_resource.bldr_url if new_resource.bldr_url
   end
 end
 
@@ -72,9 +65,7 @@ action_class do
   end
 
   def hab_command
-    cmd = ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh"]
-    cmd.push("-v #{new_resource.version}") if new_resource.version
-    cmd.push("-c #{new_resource.channel}") if new_resource.channel
+    cmd = ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", '-v 0.33.2']
     cmd.join(' ')
   end
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -26,7 +26,7 @@ property :channel, String
 
 action :install do
   if new_resource.version
-    Chef::Log.warn("Do not specify a version of Habitat with the 'hab_install' resource.")
+    Chef::Log.warn("Do not specify a version of Habitat with the 'hab_install' resource, it is ignored.")
     Chef::Log.warn("The version property of the 'hab_install' resource will be removed in a future version.")
     Chef::Log.warn("See https://github.com/chef-cookbooks/habitat/blob/master/README.md#habitat")
   end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -29,7 +29,7 @@ property :peer, String
 property :ring, String
 property :strategy, String
 property :topology, String
-property :depot_url, String
+property :bldr_url, String
 property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
 property :service_group, String
 property :config_from, String
@@ -91,7 +91,7 @@ action_class do
     case action
     when :load
       opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
-      opts << "--url #{new_resource.depot_url}" if new_resource.depot_url
+      opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
@@ -100,7 +100,7 @@ action_class do
       opts << '--permanent-peer' if new_resource.permanent_peer
       opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
       opts << "--config-from #{new_resource.config_from}" if new_resource.config_from
-      opts << "--url #{new_resource.depot_url}" if new_resource.depot_url
+      opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
       opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http

--- a/resources/sup_systemd.rb
+++ b/resources/sup_systemd.rb
@@ -29,12 +29,10 @@ property :override_name, String, default: 'default'
 property :org, String, default: 'default'
 property :peer, String
 property :ring, String
-property :hab_version, String
 property :hab_channel, String
 
 action :run do
   hab_install new_resource.name do
-    version new_resource.hab_version if new_resource.hab_version
     channel new_resource.hab_channel if new_resource.hab_channel
   end
 

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -9,13 +9,14 @@ describe 'test::install_for_chefspec' do
   end
 
   context 'when compiling the install recipe for chefspec' do
-    it 'installs habitat' do
+    it 'installs a specific version by default' do
       expect(chef_run).to install_hab_install('install habitat')
+        .with(version: '0.33.2')
     end
 
     it 'installs habitat with a version' do
       expect(chef_run).to install_hab_install('install habitat with version')
-        .with(version: '0.12.0')
+        .with(version: '0.30.0')
     end
 
     it 'installs habitat with a depot url' do

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -20,7 +20,7 @@ describe 'test::install_for_chefspec' do
 
     it 'installs habitat with a depot url' do
       expect(chef_run).to install_hab_install('install habitat with depot url')
-        .with(depot_url: 'https://localhost/v1/depot')
+        .with(depot_url: 'https://localhost')
     end
   end
 end

--- a/spec/unit/install_spec.rb
+++ b/spec/unit/install_spec.rb
@@ -9,19 +9,13 @@ describe 'test::install_for_chefspec' do
   end
 
   context 'when compiling the install recipe for chefspec' do
-    it 'installs a specific version by default' do
+    it 'install habitat' do
       expect(chef_run).to install_hab_install('install habitat')
-        .with(version: '0.33.2')
-    end
-
-    it 'installs habitat with a version' do
-      expect(chef_run).to install_hab_install('install habitat with version')
-        .with(version: '0.30.0')
     end
 
     it 'installs habitat with a depot url' do
       expect(chef_run).to install_hab_install('install habitat with depot url')
-        .with(depot_url: 'https://localhost')
+        .with(bldr_url: 'https://localhost')
     end
   end
 end

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -25,7 +25,7 @@ describe 'test::package' do
 
     it 'installs core/hab-sup with a specific depot url' do
       expect(chef_run).to install_hab_package('core/hab-sup')
-        .with(depot_url: 'http://app.acceptance.habitat.sh/v1/depot')
+        .with(depot_url: 'http://app.acceptance.habitat.sh')
     end
   end
 end

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -25,7 +25,7 @@ describe 'test::package' do
 
     it 'installs core/hab-sup with a specific depot url' do
       expect(chef_run).to install_hab_package('core/hab-sup')
-        .with(depot_url: 'http://app.acceptance.habitat.sh')
+        .with(bldr_url: 'http://app.acceptance.habitat.sh')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
+++ b/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
@@ -3,7 +3,7 @@
 hab_install 'install habitat'
 
 hab_install 'install habitat with version' do
-  version '0.12.0'
+  version '0.30.0'
 end
 
 hab_install 'install habitat with depot url' do

--- a/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
+++ b/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
@@ -7,5 +7,5 @@ hab_install 'install habitat with version' do
 end
 
 hab_install 'install habitat with depot url' do
-  depot_url 'https://localhost/v1/depot'
+  depot_url 'https://localhost'
 end

--- a/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
+++ b/test/fixtures/cookbooks/test/recipes/install_for_chefspec.rb
@@ -2,10 +2,6 @@
 # not be used in the other recipes.
 hab_install 'install habitat'
 
-hab_install 'install habitat with version' do
-  version '0.30.0'
-end
-
 hab_install 'install habitat with depot url' do
-  depot_url 'https://localhost'
+  bldr_url 'https://localhost'
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -13,5 +13,9 @@ hab_package 'core/bundler' do
 end
 
 hab_package 'core/hab-sup' do
+<<<<<<< HEAD
   depot_url 'https://app.acceptance.habitat.sh'
+=======
+  depot_url 'http://app.acceptance.habitat.sh'
+>>>>>>> Fix for hab 0.33.2 - do not provide '/v1/depot' to Hab URL
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -13,9 +13,5 @@ hab_package 'core/bundler' do
 end
 
 hab_package 'core/hab-sup' do
-<<<<<<< HEAD
-  depot_url 'https://app.acceptance.habitat.sh'
-=======
-  depot_url 'http://app.acceptance.habitat.sh'
->>>>>>> Fix for hab 0.33.2 - do not provide '/v1/depot' to Hab URL
+  bldr_url 'http://app.acceptance.habitat.sh'
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -13,5 +13,5 @@ hab_package 'core/bundler' do
 end
 
 hab_package 'core/hab-sup' do
-  depot_url 'http://app.acceptance.habitat.sh/v1/depot'
+  depot_url 'https://app.acceptance.habitat.sh'
 end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -1,5 +1,4 @@
 hab_sup 'default' do
-  hab_version '0.26.1'
   hab_channel 'stable'
 end
 

--- a/test/integration/install/default_spec.rb
+++ b/test/integration/install/default_spec.rb
@@ -4,6 +4,6 @@ describe file('/bin/hab') do
 end
 
 describe command('hab -V') do
-  its('stdout') { should match(/^hab \d+\.\d+.\d+/) }
+  its('stdout') { should match(/^hab 0.33.2\//) }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/install/default_spec.rb
+++ b/test/integration/install/default_spec.rb
@@ -3,7 +3,9 @@ describe file('/bin/hab') do
   it { should be_symlink }
 end
 
+# This needs to be updated each time Habitat is released so we ensure we're getting the version
+# required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(/^hab 0.33.2\//) }
+  its('stdout') { should match(%r{^hab 0.33.2/}) }
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Do not provide 'v1/depot' to URL - addresses https://github.com/habitat-sh/habitat/pull/3239. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
