### PR TITLE
Update to habitat 0.34.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 ### Habitat
 
-- 0.33.2
+- 0.34.1
 
 This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself. When new versions of Habitat are released, the version should be updated in these files:
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.33.0'
+version '0.34.0'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -32,9 +32,9 @@ action :install do
   end
 
   if ::File.exist?(hab_path)
-    cmd = shell_out!([hab_path, '--version', '0.33.2'])
+    cmd = shell_out!([hab_path, '--version', hab_version])
     version = %r{hab (\d*\.\d*\.\d[^\/]*)}.match(cmd.stdout)[1]
-    return if version == '0.33.2'
+    return if version == hab_version
   end
 
   remote_file ::File.join(Chef::Config[:file_cache_path], 'hab-install.sh') do
@@ -59,6 +59,12 @@ action :upgrade do
 end
 
 action_class do
+  HAB_VERSION = '0.34.1'
+
+  def hab_version
+    HAB_VERSION
+  end
+
   def hab_path
     if platform_family?('mac_os_x')
       '/usr/local/bin/hab'
@@ -72,7 +78,7 @@ action_class do
   end
 
   def hab_command
-    cmd = ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", '-v 0.33.2']
+    cmd = ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", "-v #{hab_version}"]
     cmd.join(' ')
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -13,5 +13,5 @@ hab_package 'core/bundler' do
 end
 
 hab_package 'core/hab-sup' do
-  bldr_url 'http://app.acceptance.habitat.sh'
+  bldr_url 'http://acceptance.habitat.sh'
 end

--- a/test/integration/install/default_spec.rb
+++ b/test/integration/install/default_spec.rb
@@ -6,6 +6,6 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.33.2/}) }
+  its('stdout') { should match(%r{^hab 0.34.1/}) }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/sup/default_spec.rb
+++ b/test/integration/sup/default_spec.rb
@@ -1,5 +1,5 @@
 describe command('/bin/hab sup -h') do
-  its(:exit_status) { should be_zero }
+  its(:stdout) { should match(/The Habitat Supervisor/) }
 end
 
 describe file('/hab/sup/default/data/services.dat') do


### PR DESCRIPTION
This commit updates hab_install to install version 0.34.1, released on 2017-10-01. It also moves the version to a constant and helper method in the action_class so we have a single place to modify it in the code.

Signed-off-by: Joshua Timberman <joshua@chef.io>