### PR TITLE
Add support for the new version_compare helper in Chef 13.5

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -161,11 +161,11 @@ class Chef
 
         # This is used by the superclass Chef::Provider::Package
         def version_compare(v1, v2)
-          return unless Chef::Package::Provider.methods.include?(:version_compare)
+          return unless Chef::Provider::Package.methods.include?(:version_compare)
 
           # Convert the package version (X.Y.Z/DATE) into a version that Mixlib::Versioning understands (X.Y.Z+DATE)
-          hab_v1 = Mixlib::Versioning.parse(v1.tr("/", "+"))
-          hab_v2 = Mixlib::Versioning.parse(v2.tr("/", "+"))
+          hab_v1 = Mixlib::Versioning.parse(v1.tr('/', '+'))
+          hab_v2 = Mixlib::Versioning.parse(v2.tr('/', '+'))
 
           hab_v1 <=> hab_v2
         end

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -158,6 +158,17 @@ class Chef
             return current_version.squeeze('/') == new_resource.version.squeeze('/')
           end
         end
+
+        # This is used by the superclass Chef::Provider::Package
+        def version_compare(v1, v2)
+          return unless Chef::Package::Provider.methods.include?(:version_compare)
+
+          # Convert the package version (X.Y.Z/DATE) into a version that Mixlib::Versioning understands (X.Y.Z+DATE)
+          hab_v1 = Mixlib::Versioning.parse(v1.tr("/", "+"))
+          hab_v2 = Mixlib::Versioning.parse(v2.tr("/", "+"))
+
+          hab_v1 <=> hab_v2
+        end
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.34.0'
+version '0.34.1'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -28,7 +28,7 @@ action :install do
   if new_resource.version
     Chef::Log.warn("Do not specify a version of Habitat with the 'hab_install' resource, it is ignored.")
     Chef::Log.warn("The version property of the 'hab_install' resource will be removed in a future version.")
-    Chef::Log.warn("See https://github.com/chef-cookbooks/habitat/blob/master/README.md#habitat")
+    Chef::Log.warn('See https://github.com/chef-cookbooks/habitat/blob/master/README.md#habitat')
   end
 
   if ::File.exist?(hab_path)
@@ -59,7 +59,7 @@ action :upgrade do
 end
 
 action_class do
-  HAB_VERSION = '0.34.1'
+  HAB_VERSION = '0.34.1'.freeze
 
   def hab_version
     HAB_VERSION

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -25,7 +25,7 @@ describe 'test::package' do
 
     it 'installs core/hab-sup with a specific depot url' do
       expect(chef_run).to install_hab_package('core/hab-sup')
-        .with(bldr_url: 'http://app.acceptance.habitat.sh')
+        .with(bldr_url: 'http://bldr.acceptance.habitat.sh')
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Add the `version_compare` method. 

### Issues Resolved

Failures in Chef 13.5.11

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
