### PR TITLE
honor options from package provider

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -63,7 +63,7 @@ class Chef
 
         def install_package(names, versions)
           names.zip(versions).map do |n, v|
-            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url, "#{strip_version(n)}/#{v}")
+            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url, "#{strip_version(n)}/#{v}", new_resource.options)
           end
         end
 

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -25,7 +25,12 @@ describe 'test::package' do
 
     it 'installs core/hab-sup with a specific depot url' do
       expect(chef_run).to install_hab_package('core/hab-sup')
-        .with(bldr_url: 'http://bldr.acceptance.habitat.sh')
+        .with(bldr_url: 'https://bldr.acceptance.habitat.sh')
+    end
+
+    it 'installs core/htop with binlink' do
+      expect(chef_run).to install_hab_package('core/htop')
+        .with(options: ['--binlink'])
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -12,6 +12,10 @@ hab_package 'core/bundler' do
   version '1.13.3/20161011123917'
 end
 
+hab_package 'core/htop' do
+  options '--binlink'
+end
+
 hab_package 'core/hab-sup' do
-  bldr_url 'http://bldr.acceptance.habitat.sh'
+  bldr_url 'https://bldr.acceptance.habitat.sh'
 end

--- a/test/integration/package/default_spec.rb
+++ b/test/integration/package/default_spec.rb
@@ -29,3 +29,8 @@ describe command('hab pkg path core/hab-sup') do
   its('exit_status') { should eq 0 }
   its('stdout') { should match(%r{/hab/pkgs/core/hab-sup}) }
 end
+
+describe file('/bin/htop') do
+  it { should be_symlink }
+  its(:link_path) { should match(%r{/hab/pkgs/core/htop}) }
+end


### PR DESCRIPTION
The package provider has an options property. We should use this so we
can inject additional options to the hab pkg install command, such as
--binlink.

This closes #3.

Signed-off-by: Joshua Timberman <joshua@chef.io>