### PR TITLE
create user in hab_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 ### Habitat
 
-- 0.36.0
+- 0.37.0
 
 This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself. When new versions of Habitat are released, the version should be updated in these files:
 
@@ -54,6 +54,7 @@ Installs Habitat on the system using the [install script](https://raw.githubuser
 - `install_url`: URL to the install script, default is from the [habitat repo](https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh)
 - `bldr_url`: Optional URL to an alternate Builder (defaults to the public Builder)
 - `channel`: The release channel to install from (defaults to `stable`)
+- `create_user`: Creates the `hab` system user (defaults to `true`)
 
 #### Examples
 
@@ -63,7 +64,7 @@ hab_install 'install habitat'
 
 ```ruby
 hab_install 'install habitat' do
-  bldr_url "http://localhost"
+  bldr_url 'http://localhost'
 end
 ```
 
@@ -85,26 +86,28 @@ This resource is written as a library resource because it subclasses Chef's `pac
 - `bldr_url`: The habitat builder url where packages will be downloaded from (defaults to public habitat builder)
 - `channel`: The release channel to install from (defaults to `stable`)
 
-While it is valid to pass the version and release with a Habitat package as a "fully qualified package identifier" when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
+While it is valid to pass the version and release with a Habitat package as a fully qualified package identifier when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
 
 #### Examples
 
 ```ruby
-hab_package "core/redis"
+hab_package 'core/redis'
 
-hab_package "core/redis" do
-  version "3.2.3"
-  channel "unstable"
+hab_package 'core/redis' do
+  version '3.2.3'
+  channel 'unstable'
 end
 
-hab_package "core/redis" do
-  version "3.2.3/20160920131015"
+hab_package 'core/redis' do
+  version '3.2.3/20160920131015'
 end
 ```
 
 ### hab_service
 
 Manages a Habitat application service using `hab sup`/`hab service`. This requires that `core/hab-sup` be running as a service. See the `hab_sup` resource documentation below for more information about how to set that up with this cookbook.
+
+*Note:* Applications may run as a specific user. Often with Habitat, the default is `hab`, or `root`. If the application requires another user, then it should be created with Chef's `user` resource.
 
 #### Actions
 
@@ -139,19 +142,33 @@ Some properties are only valid for `start` or `load` actions. See the descriptio
 
 ```ruby
 # install and load nginx
-hab_package "core/nginx"
-hab_service "core/nginx"
+hab_package 'core/nginx'
+hab_service 'core/nginx'
 
-hab_service "core/nginx unload" do
-  service_name "core/nginx"
+hab_service 'core/nginx unload' do
+  service_name 'core/nginx'
   action :unload
 end
 
 # pass the strategy and topology options to hab service commands (load by default)
-hab_service "core/redis" do
+hab_service 'core/redis' do
   strategy 'rolling'
   topology 'standalone'
 end
+```
+
+If the service has it's own user specified that is not the `hab` user, don't create the `hab` user on install, and instead create the application user with Chef's `user` resource
+
+```ruby
+hab_install 'install habitat' do
+  create_user false
+end
+
+user 'acme-apps' do
+  system true
+end
+
+hab_service 'acme/apps'
 ```
 
 ### hab_sup
@@ -179,7 +196,7 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 
 ```ruby
 # set up with just the defaults
-hab_sup "default"
+hab_sup 'default'
 
 # run with an override name, requires changing listen_http and
 # listen_gossip if a default supervisor is running
@@ -222,7 +239,7 @@ the current timestamp in seconds since 1970-01-01 00:00:00 UTC.
 #### Examples
 
 ```ruby
-hab_config "nginx.default" do
+hab_config 'nginx.default' do
   config({
     worker_count: 2,
     http: {

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -23,12 +23,19 @@ property :install_url, String, default: 'https://raw.githubusercontent.com/habit
 property :bldr_url, String
 property :version, String
 property :channel, String
+property :create_user, [true, false], default: true
 
 action :install do
   if new_resource.version
     Chef::Log.warn("Do not specify a version of Habitat with the 'hab_install' resource, it is ignored.")
     Chef::Log.warn("The version property of the 'hab_install' resource will be removed in a future version.")
     Chef::Log.warn('See https://github.com/chef-cookbooks/habitat/blob/master/README.md#habitat')
+  end
+
+  if new_resource.create_user
+    user 'hab' do
+      system true
+    end
   end
 
   if ::File.exist?(hab_path)
@@ -39,6 +46,7 @@ action :install do
 
   remote_file ::File.join(Chef::Config[:file_cache_path], 'hab-install.sh') do
     source new_resource.install_url
+    sensitive true
   end
 
   execute 'installing with hab-install.sh' do
@@ -50,6 +58,7 @@ end
 action :upgrade do
   remote_file ::File.join(Chef::Config[:file_cache_path], 'hab-install.sh') do
     source new_resource.install_url
+    sensitive true
   end
 
   execute 'installing with hab-install.sh' do

--- a/test/fixtures/cookbooks/test/recipes/config.rb
+++ b/test/fixtures/cookbooks/test/recipes/config.rb
@@ -1,9 +1,6 @@
 include_recipe '::install'
 hab_sup 'default'
 
-user 'hab'
-group 'hab'
-
 hab_package 'core/nginx'
 hab_service 'core/nginx'
 

--- a/test/fixtures/cookbooks/test/recipes/install_no_user.rb
+++ b/test/fixtures/cookbooks/test/recipes/install_no_user.rb
@@ -1,0 +1,3 @@
+hab_install 'no-users-here' do
+  create_user false
+end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -2,9 +2,6 @@ hab_sup 'default' do
   hab_channel 'stable'
 end
 
-user 'hab'
-group 'hab'
-
 hab_package 'core/nginx'
 hab_service 'core/nginx'
 

--- a/test/integration/install/default_spec.rb
+++ b/test/integration/install/default_spec.rb
@@ -1,3 +1,7 @@
+describe user('hab') do
+  it { should exist }
+end
+
 describe file('/bin/hab') do
   it { should exist }
   it { should be_symlink }

--- a/test/integration/install_no_user/default_spec.rb
+++ b/test/integration/install_no_user/default_spec.rb
@@ -1,0 +1,3 @@
+describe user('hab') do
+  it { should_not exist }
+end

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -1,7 +1,3 @@
-describe user('hab') do
-  it { should exist }
-end
-
 describe directory('/hab/pkgs/core/nginx') do
   it { should exist }
 end


### PR DESCRIPTION
Fixes #54

This change adds a property to the `hab_install` resource that will
automatically create a `hab` system user. This is because many
services in Habitat's core plans run as the "hab" user, and we want to
avoid services failing to start or failed chef client runs because the
user wasn't there.

End users can opt out of the user creation by setting the property to
false, and create their own user in their recipes if their service
runs as something that isn't `hab`.

Signed-off-by: Joshua Timberman <joshua@chef.io>
