### PR TITLE
Fixed the failing test for lint / unit in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
+  - chef gem install toml
   - chef --version
   - cookstyle --version
   - foodcritic --version


### PR DESCRIPTION
ChefDK removed toml and uses tomlrb, so we need to install the toml gem now in order for the lint / spec check to pass in travis. This works with the cookbook as normal because it's in the metadata as a gem, but chefspec doesn't run chef-client so it doesn't install the gems defined in metadata.