### PR TITLE
Set supervisor service to enable

### DIFF
--- a/libraries/resource_hab_sup_systemd.rb
+++ b/libraries/resource_hab_sup_systemd.rb
@@ -44,7 +44,7 @@ class Chef
 
         service "hab-sup-#{new_resource.override_name}" do
           subscribes :restart, "systemd_unit[hab-sup-#{new_resource.override_name}.service]"
-          action :start
+          action [:enable, :start]
         end
       end
     end

--- a/libraries/resource_hab_sup_sysvinit.rb
+++ b/libraries/resource_hab_sup_sysvinit.rb
@@ -42,7 +42,7 @@ class Chef
 
         service "hab-sup-#{new_resource.override_name}" do
           subscribes :restart, "template[/etc/init.d/hab-sup-#{new_resource.override_name}]"
-          action :start
+          action [:enable, :start]
         end
       end
     end

--- a/libraries/resource_hab_sup_upstart.rb
+++ b/libraries/resource_hab_sup_upstart.rb
@@ -43,7 +43,7 @@ class Chef
           # RHEL 6 includes Upstart but Chef won't use it unless we specify the provider.
           provider Chef::Provider::Service::Upstart
           subscribes :restart, "template[/etc/init/hab-sup-#{new_resource.override_name}.conf]"
-          action :start
+          action [:enable, :start]
         end
       end
     end


### PR DESCRIPTION
### Description

Currently, the supervisor service is not enabled, causing the supervisor to not come back up if a box is restarted until the next Chef run.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
