### PR TITLE
update to habitat 0.53.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 ### Habitat
 
-- 0.52.0
+- 0.53.0
 
 This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself. When new versions of Habitat are released, the version should be updated in these files:
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.52.0'
+version '0.53.0'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -65,7 +65,7 @@ action :upgrade do
 end
 
 action_class do
-  HAB_VERSION = '0.52.0'.freeze
+  HAB_VERSION = '0.53.0'.freeze
 
   def hab_version
     HAB_VERSION

--- a/test/integration/config/default_spec.rb
+++ b/test/integration/config/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.52.0/}) }
+  its('stdout') { should match(%r{^hab 0.53.0/}) }
   its('exit_status') { should eq 0 }
 end
 

--- a/test/integration/package/default_spec.rb
+++ b/test/integration/package/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.52.0/}) }
+  its('stdout') { should match(%r{^hab 0.53.0/}) }
   its('exit_status') { should eq 0 }
 end
 


### PR DESCRIPTION
We were going to automate these releases with expeditor, but we haven't had cycles to get that done this week. In the interest of getting the cookbook released to support the new version of habitat released recently, here's 0.53.0. 😀 