### PR TITLE
Fix install resource to prevent conversion of array to string errors.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.53.0'
+version '0.53.1'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -27,7 +27,9 @@ property :channel, String
 property :create_user, [true, false], default: true
 
 action :install do
-  package %w(curl tar)
+  %w(curl tar).each do |pkg|
+    package pkg
+  end
 
   if new_resource.create_user
     user 'hab' do


### PR DESCRIPTION
Signed-off-by: Nathan Cerny <ncerny@gmail.com>

### Description

The install resource passes an array into the package resource within Chef.  This gives an implicit conversion of array to string error.  This fixes that issue by iterating over the array.

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
