### PR TITLE
Add auto_update parameter to hab-sup resource

### DIFF
--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -32,6 +32,7 @@ class Chef
       property :peer, String
       property :ring, String
       property :hab_channel, String
+      property :auto_update, [true, false], default: false
 
       action :run do
         hab_install new_resource.name do
@@ -51,6 +52,7 @@ class Chef
           opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
           opts << "--peer #{new_resource.peer}" if new_resource.peer
           opts << "--ring #{new_resource.ring}" if new_resource.ring
+          opts << '--auto-update' if new_resource.auto_update
           opts.join(' ')
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.53.0'
+version '0.53.1'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -27,7 +27,9 @@ property :channel, String
 property :create_user, [true, false], default: true
 
 action :install do
-  package %w(curl tar)
+  %w(curl tar).each do |pkg|
+    package pkg
+  end
 
   if new_resource.create_user
     user 'hab' do


### PR DESCRIPTION
### Description

The habitat supervisor has the ability to automatically update itself.  This can be preferred over having chef-update it.  This change adds in the ability to pass that flag to the habitat supervisor.

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
