### PR TITLE
Fix conversion error in install resource

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -27,7 +27,9 @@ property :channel, String
 property :create_user, [true, false], default: true
 
 action :install do
-  package %w(curl tar)
+  %w(curl tar).each do |pkg|
+    package pkg
+  end
 
   if new_resource.create_user
     user 'hab' do


### PR DESCRIPTION
Signed-off-by: Nathan Cerny <ncerny@gmail.com>

### Description

The install resource passes an array into the package resource within Chef. This gives an implicit conversion of array to string error. This fixes that issue by iterating over the array.

### Issues Resolved


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
