### PR TITLE
Add: bldr_url property for hab_sup

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 
 #### Properties
 
+- `bldr_url`: The Builder URL for the `hab_package` resource, if needed
 - `permanent_peer`: Only valid for `:start` action, passes `--permanent-peer` to the hab command
 - `listen_gossip`: Only valid for `:start` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
 - `listen_http`: Only valid for `:start` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
@@ -207,6 +208,14 @@ hab_sup 'test-options' do
   override_name 'myapps'
   listen_http '0.0.0.0:9999'
   listen_gossip '0.0.0.0:9998'
+end
+```
+
+```ruby
+# Use with an on-prem Builder
+# Access to public builder may not be available
+hab_sup 'default' do
+  bldr_url 'https://bldr.private.net'
 end
 ```
 

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -24,6 +24,7 @@ class Chef
         false
       end
 
+      property :bldr_url, String
       property :permanent_peer, [true, false], default: false
       property :listen_gossip, String
       property :listen_http, String
@@ -39,7 +40,9 @@ class Chef
           channel new_resource.hab_channel if new_resource.hab_channel
         end
 
-        hab_package 'core/hab-sup'
+        hab_package 'core/hab-sup' do
+          bldr_url new_resource.bldr_url if new_resource.bldr_url
+        end
       end
 
       action_class do

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -1,4 +1,6 @@
-hab_sup 'tester'
+hab_sup 'tester' do
+  bldr_url 'https://willem.habitat.sh'
+end
 
 ruby_block 'wait-for-sup-default-startup' do
   block do


### PR DESCRIPTION
### Description

Because the `hab_sup` resource explicitly ensures that the supervisor is
installed, it includes a `hab_package` resource.

However, for users in a private environment, with an on-prem Builder, it
is possible that access to upstream/public Builder is neither possible
nor desirable.

This adds the ability to specify the `:bldr_url` property to `hab_sup`,
which is then passed through to the `hab_package` resource.

### Issues Resolved

No issues connected.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Stephen Nelson-Smith <stephen@atalanta-systems.com>
