### PR TITLE
Fix hab_svc when using custom ip:port for supervisor

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -23,7 +23,7 @@ property :running, [true, false], default: false, desired_state: true
 # hab sup options which get included based on the action of the resource
 property :permanent_peer, [true, false], default: false
 property :listen_gossip, String
-property :listen_http, String
+property :listen_http, String, desired_state: false
 property :org, String, default: 'default'
 property :peer, String
 property :ring, String
@@ -61,7 +61,7 @@ end
 # NoMethodError.
 #
 def service_up?(svc_name)
-  http_uri = listen_http ? listen_http : 'http://localhost:9631'
+  http_uri = listen_http ? "http://#{listen_http}" : 'http://localhost:9631'
 
   begin
     TCPSocket.new(URI(http_uri).host, URI(http_uri).port).close


### PR DESCRIPTION
### Description

Mark `hab_svc`'s `listen_http` property with `desired_state: false`, so
that it's value is available during `load_current_value` hook.

Make sure we can parse it with `URI()` to extract host and port.

### Issues Resolved

Fixes #95 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
