### PR TITLE
Update for 0.56.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This cookbook provides resources for working with [Habitat](https://habitat.sh).
 
 ### Habitat
 
-- Habitat version: 0.55.0
+- Habitat version: 0.56.0
 
 This cookbook is developed lockstep with the latest release of Habitat to ensure compatibility, going forward from 0.33.0 of the cookbook and 0.33.2 of Habitat itself. When new versions of Habitat are released, the version should be updated in these files:
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Habitat related resources for chef-client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.55.0'
+version '0.56.0'
 
 %w(ubuntu debian redhat centos suse scientific oracle amazon opensuse opensuseleap).each do |os|
   supports os

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -65,7 +65,7 @@ action :upgrade do
 end
 
 action_class do
-  HAB_VERSION = '0.55.0'.freeze
+  HAB_VERSION = '0.56.0'.freeze
 
   def hab_version
     HAB_VERSION

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -90,19 +90,19 @@ def service_up?(svc_name)
 end
 
 action :load do
-  execute "hab sup load #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.loaded
+  execute "hab svc load #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.loaded
 end
 
 action :unload do
-  execute "hab sup unload #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.loaded
+  execute "hab svc unload #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.loaded
 end
 
 action :start do
-  execute "hab sup start #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.running
+  execute "hab svc start #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.running
 end
 
 action :stop do
-  execute "hab sup stop #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.running
+  execute "hab svc stop #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.running
 end
 
 action :restart do

--- a/test/integration/config/default_spec.rb
+++ b/test/integration/config/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.55.0/}) }
+  its('stdout') { should match(%r{^hab 0.56.0/}) }
   its('exit_status') { should eq 0 }
 end
 

--- a/test/integration/package/default_spec.rb
+++ b/test/integration/package/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.55.0/}) }
+  its('stdout') { should match(%r{^hab 0.56.0/}) }
   its('exit_status') { should eq 0 }
 end
 


### PR DESCRIPTION
Bumped the version in the all the places. Also replaced `hab sup
start/stop/load/unload` with `hab svc start/stop/load/unload` as the sup
variants were removed in 0.56.0

Signed-off-by: Nolan Davidson <ndavidson@chef.io>

### Description

Bumps hab version to 0.56.0

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
