### PR TITLE
adding supervisor and service multiple peering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ Some properties are only valid for `start` or `load` actions. See the descriptio
 - `listen_gossip`: Only valid for `:start` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
 - `listen_http`: Only valid for `:start` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
 - `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
-- `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command
+- `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command. If an array of multiple peers are specified then a `--peer` flag is added for each.
 - `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
 - `strategy`: Only valid for `:start` or `:load` actions, passes `--strategy` with the specified update strategy to the hab command
 - `topology`: Only valid for `:start` or `:load` actions, passes `--topology` with the specified service topology to the hab command
 - `bldr_url`: Only valid for `:start` or `:load` actions, passes `--url` with the specified Builder URL to the hab command. For local repos, use 'local'.
-- `bind`: Only valid for `:start` or `:load` actions, passes `--bind` with the specified services to bind to the hab command
+- `bind`: Only valid for `:start` or `:load` actions, passes `--bind` with the specified services to bind to the hab command. If an array of multiple service binds are specified then a `--bind` flag is added for each.
 - `service_group`: Only valid for `:start` or `:load` actions, passes `--group` with the specified service group to the hab command
 - `config_from`: Only valid for `:start` action, passes `--config-from` with the specified directory to the hab command
 - `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -30,7 +30,7 @@ class Chef
       property :listen_http, String
       property :override_name, String, default: 'default'
       property :org, String, default: 'default'
-      property :peer, String
+      property :peer, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
       property :ring, String
       property :hab_channel, String
       property :auto_update, [true, false], default: false
@@ -53,7 +53,7 @@ class Chef
           opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http
           opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'
           opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
-          opts << "--peer #{new_resource.peer}" if new_resource.peer
+          opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
           opts << "--ring #{new_resource.ring}" if new_resource.ring
           opts << '--auto-update' if new_resource.auto_update
           opts.join(' ')

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -121,7 +121,7 @@ end
 action_class do
   def sup_options
     opts = []
-    
+
     # certain options are only valid for specific `hab sup` subcommands.
     case action
     when :load

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -25,7 +25,7 @@ property :permanent_peer, [true, false], default: false
 property :listen_gossip, String
 property :listen_http, String, desired_state: false
 property :org, String, default: 'default'
-property :peer, String
+property :peer, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
 property :ring, String
 property :strategy, String
 property :topology, String
@@ -121,7 +121,7 @@ end
 action_class do
   def sup_options
     opts = []
-
+    
     # certain options are only valid for specific `hab sup` subcommands.
     case action
     when :load
@@ -144,7 +144,7 @@ action_class do
       opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
       opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http
       opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
-      opts << "--peer #{new_resource.peer}" if new_resource.peer
+      opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
       opts << "--ring #{new_resource.ring}" if new_resource.ring
     end
 

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -34,14 +34,31 @@ describe 'test::service' do
     end
 
     it 'loads a service with a single peer' do
-      expect(chef_run).to load_hab_service('core/postgresql-client').with(
+      expect(chef_run).to load_hab_service('core/rabbitmq').with(
         peer: ['127.0.0.2']
       )
     end
 
     it 'loads a service with multiple peers' do
-      expect(chef_run).to load_hab_service('core/postgresql').with(
+      expect(chef_run).to load_hab_service('core/sensu').with(
         peer: ['127.0.0.2', '127.0.0.3']
+      )
+    end
+
+    it 'loads a service with a single bind' do
+      expect(chef_run).to load_hab_service('core/ruby-rails-sample').with(
+        bind: [
+          'database:postgresql.default',
+        ]
+      )
+    end
+
+    it 'loads a service with multiple binds' do
+      expect(chef_run).to load_hab_service('core/sensu').with(
+        bind: [
+          'rabbitmq:rabbitmq.default',
+          'redis:redis.default',
+        ]
       )
     end
   end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -32,5 +32,17 @@ describe 'test::service' do
         channel: :stable
       )
     end
+
+    it 'loads a service with a single peer' do
+      expect(chef_run).to load_hab_service('core/postgresql-client').with(
+        peer: ['127.0.0.2']
+      )
+    end
+
+    it 'loads a service with multiple peers' do
+      expect(chef_run).to load_hab_service('core/postgresql').with(
+        peer: ['127.0.0.2', '127.0.0.3']
+      )
+    end
   end
 end

--- a/spec/unit/sup_spec.rb
+++ b/spec/unit/sup_spec.rb
@@ -16,6 +16,21 @@ describe 'test::sup' do
           )
       end
 
+      it 'run hab sup with a single peer' do
+        expect(chef_run).to run_hab_sup('single_peer').with(
+          override_name: 'single_peer',
+          peer: ['127.0.0.2']
+        )
+      end
+
+      it 'runs hab sup with multiple peers' do
+        expect(chef_run).to run_hab_sup('multiple_peers')
+          .with(
+            override_name: 'multiple_peers',
+            peer: ['127.0.0.2', '127.0.0.3']
+          )
+      end
+
       it 'handles installing hab for us' do
         expect(chef_run).to install_hab_install('tester')
       end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -68,3 +68,14 @@ hab_service 'core/ruby-rails-sample' do
     'fakething:otherthing.default',
   ]
 end
+
+# Test peers
+hab_package 'core/postgresql-client'
+hab_service 'core/postgresql-client' do
+  peer '127.0.0.2'
+end
+
+hab_package 'core/postgresql'
+hab_service 'core/postgresql' do
+  peer ['127.0.0.2', '127.0.0.3']
+end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -60,22 +60,29 @@ end
 hab_package 'core/memcached'
 hab_service 'core/memcached'
 
-# Test binds
+# Test Peers and Binds
+
+# Single string bind
 hab_package 'core/ruby-rails-sample'
 hab_service 'core/ruby-rails-sample' do
-  bind [
-    'database:postgresql.default',
-    'fakething:otherthing.default',
-  ]
+  bind 'database:postgresql.default'
 end
 
-# Test peers
-hab_package 'core/postgresql-client'
-hab_service 'core/postgresql-client' do
+# Single string peer
+hab_package 'core/rabbitmq'
+hab_service 'core/rabbitmq' do
   peer '127.0.0.2'
 end
 
-hab_package 'core/postgresql'
-hab_service 'core/postgresql' do
-  peer ['127.0.0.2', '127.0.0.3']
+# Multiple peers and binds
+hab_package 'core/sensu'
+hab_service 'core/sensu' do
+  peer [
+    '127.0.0.2',
+    '127.0.0.3',
+  ]
+  bind [
+    'rabbitmq:rabbitmq.default',
+    'redis:redis.default',
+  ]
 end

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -26,6 +26,8 @@ end
 
 hab_sup 'single_peer' do
   override_name 'single_peer'
+  listen_http '0.0.0.0:8999'
+  listen_gossip '0.0.0.0:8998'
   peer '127.0.0.2'
 end
 
@@ -40,8 +42,8 @@ end
 hab_sup 'multiple_peers' do
   override_name 'multiple_peers'
   peer ['127.0.0.2', '127.0.0.3']
-  listen_http '0.0.0.0:9999'
-  listen_gossip '0.0.0.0:9998'
+  listen_http '0.0.0.0:7999'
+  listen_gossip '0.0.0.0:7998'
 end
 
 ruby_block 'wait-for-sup-multiple_peers-startup' do

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -29,7 +29,7 @@ hab_sup 'single_peer' do
   peer '127.0.0.2'
 end
 
-ruby_block 'wait-for-sup-default-startup' do
+ruby_block 'wait-for-sup-single_peer-startup' do
   block do
     raise unless File.exist?('/hab/sup/single_peer/data/services.dat')
   end
@@ -44,7 +44,7 @@ hab_sup 'multiple_peers' do
   listen_gossip '0.0.0.0:9998'
 end
 
-ruby_block 'wait-for-sup-chef-es-startup' do
+ruby_block 'wait-for-sup-multiple_peers-startup' do
   block do
     raise unless File.exist?('/hab/sup/multiple_peers/data/services.dat')
   end

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -23,3 +23,31 @@ ruby_block 'wait-for-sup-chef-es-startup' do
   retries 30
   retry_delay 1
 end
+
+hab_sup 'single_peer' do
+  override_name 'single_peer'
+  peer '127.0.0.2'
+end
+
+ruby_block 'wait-for-sup-default-startup' do
+  block do
+    raise unless File.exist?('/hab/sup/single_peer/data/services.dat')
+  end
+  retries 30
+  retry_delay 1
+end
+
+hab_sup 'multiple_peers' do
+  override_name 'multiple_peers'
+  peer ['127.0.0.2', '127.0.0.3']
+  listen_http '0.0.0.0:9999'
+  listen_gossip '0.0.0.0:9998'
+end
+
+ruby_block 'wait-for-sup-chef-es-startup' do
+  block do
+    raise unless File.exist?('/hab/sup/multiple_peers/data/services.dat')
+  end
+  retries 30
+  retry_delay 1
+end

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -23,5 +23,5 @@ end
 
 describe file('/hab/sup/default/specs/ruby-rails-sample.spec') do
   it { should exist }
-  its(:content) { should match(/binds = \["database:postgresql.default", "fakething:otherthing.default"\]/) }
+  its(:content) { should match(/binds = \["database:postgresql.default"\]/) }
 end


### PR DESCRIPTION
Signed-off-by: John Kerry <jk185160@ncr.com>

### Description

Allows multiple initial peers in both the sup and service resource

### Issues Resolved
resolves #92 
Solves the same need as PR #84 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
