### PR TITLE
Fix #103 and remove options from svc start

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -80,7 +80,7 @@ action :upgrade do
 end
 
 action_class do
-  HAB_VERSION = '0.56.0'.freeze
+  HAB_VERSION = '0.57.0'.freeze
 
   def hab_version
     HAB_VERSION

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -82,7 +82,7 @@ def service_up?(svc_name)
   end
 
   begin
-    sup_for_service_name['process']['state'] == 'Up'
+    sup_for_service_name['process']['state'] == 'up'
   rescue
     Chef::Log.debug("#{service_name} not found the Habitat supervisor")
     false
@@ -98,6 +98,7 @@ action :unload do
 end
 
 action :start do
+  action_load
   execute "hab svc start #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.running
 end
 
@@ -132,13 +133,12 @@ action_class do
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
-    when :start
+    when :start, :stop
       opts << '--permanent-peer' if new_resource.permanent_peer
       opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
       opts << "--config-from #{new_resource.config_from}" if new_resource.config_from
       unless new_resource.bldr_url == 'local'
         opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
-        opts << "--channel #{new_resource.channel}"
       end
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
@@ -146,8 +146,6 @@ action_class do
       opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
       opts << "--peer #{new_resource.peer}" if new_resource.peer
       opts << "--ring #{new_resource.ring}" if new_resource.ring
-      opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
-      opts << "--topology #{new_resource.topology}" if new_resource.topology
     end
 
     opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'

--- a/test/integration/config/default_spec.rb
+++ b/test/integration/config/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.56.0/}) }
+  its('stdout') { should match(%r{^hab 0.57.0/}) }
   its('exit_status') { should eq 0 }
 end
 

--- a/test/integration/package/default_spec.rb
+++ b/test/integration/package/default_spec.rb
@@ -10,7 +10,7 @@ end
 # This needs to be updated each time Habitat is released so we ensure we're getting the version
 # required by this cookbook.
 describe command('hab -V') do
-  its('stdout') { should match(%r{^hab 0.56.0/}) }
+  its('stdout') { should match(%r{^hab 0.57.0/}) }
   its('exit_status') { should eq 0 }
 end
 


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

This PR attempts to fix issue #103. Under Hab 0.56.0 and greater, the hab svc start and stop commands do not expect to receive some supervisor options like --channel etc which were previously supported.

This change removes unsupported options from the :start and :stop actions. It further ensures that the service is loaded correctly using hab svc load (by way of the action_load method) before attempting to start it.

This PR also upgrades the installed version of Hab to 0.57.0, just released today. This was done to fix https://github.com/habitat-sh/habitat/issues/5178, which was hit under 0.56.1.

### Issues Resolved

#103 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
