### PR TITLE
Source helper functions script

### DIFF
--- a/.expeditor/update_hab_release.sh
+++ b/.expeditor/update_hab_release.sh
@@ -24,6 +24,7 @@ echo "${VERSION}" > VERSION
 git add .
 git commit -m "update to habitat $VERSION"
 
+. /helper_functions.sh
 open_pull_request
 
 git checkout -


### PR DESCRIPTION
`open_pull_request` is not found when run through expeditor without sourcing this first.