### PR TITLE
small fix to create the hab group, this will make the hab_install res…

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -32,6 +32,7 @@ action :install do
 
   if new_resource.create_user
     group 'hab'
+
     user 'hab' do
       gid 'hab'
       system true

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -31,7 +31,9 @@ action :install do
   package %w(curl tar)
 
   if new_resource.create_user
+    group 'hab'
     user 'hab' do
+      gid 'hab'
       system true
     end
   end


### PR DESCRIPTION
…ource compatible with SLES 12

Signed-off-by: devoptimist <stephenb583@gmail.com>

### Description
full context https://github.com/chef-cookbooks/habitat/issues/107

This change creates the hab group in the install resource. before the hab user is created.
This is done because not all Linux OS's use the default behaviour of the useradd command.

### Issues Resolved

https://github.com/chef-cookbooks/habitat/issues/107


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
