### PR TITLE
Call with full path to clean_array

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -87,7 +87,7 @@ class Chef
         private
 
         def hab(*command)
-          shell_out_with_timeout!(clean_array('hab', *command))
+          shell_out_with_timeout!(*Chef::Mixin::ShellOut.clean_array('hab', *command))
         rescue Errno::ENOENT
           Chef::Log.fatal("'hab' binary not found, use the 'hab_install' resource to install it first")
           raise


### PR DESCRIPTION
### Description

Fixes undefined method error being thrown in latest Chef 14  

### Issues Resolved

https://github.com/chef-cookbooks/habitat/issues/109

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
