### PR TITLE
address chef 14.3.x shell_out deprecations

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -1,4 +1,4 @@
-# Copyright:: 2016-2018, Chef Software, Inc.
+# Copyright:: 2016-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,7 +87,11 @@ class Chef
         private
 
         def hab(*command)
-          shell_out_with_timeout!(clean_array('hab', *command))
+          if Gem::Requirement.new(">= 14.3.20").satisfied_by?(Gem::Version.new(Chef::VERSION))
+            shell_out!('hab', *command)
+          else
+            shell_out_with_timeout!(clean_array('hab', *command))
+          end
         rescue Errno::ENOENT
           Chef::Log.fatal("'hab' binary not found, use the 'hab_install' resource to install it first")
           raise

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,4 +1,4 @@
-# Copyright:: 2017-2018 Chef Software, Inc.
+# Copyright:: 2017-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,13 +53,17 @@ action :apply do
     opts << ['--org', new_resource.org] if new_resource.org
     opts << ['--ring', new_resource.ring] if new_resource.ring
 
+    command = [ 'hab', 'config', 'apply', opts, new_resource.service_group,
+                incarnation, tempfile.path ]
     tempfile = Tempfile.new(['hab_config', '.toml'])
     begin
       tempfile.write(TOML::Generator.new(new_resource.config).body)
       tempfile.close
-      shell_out_compact!(['hab', 'config', 'apply', opts,
-                          new_resource.service_group, incarnation,
-                          tempfile.path])
+      if Gem::Requirement.new(">= 14.3.20").satisfied_by?(Gem::Version.new(Chef::VERSION))
+        shell_out!(*command)
+      else
+        shell_out_compact!(*command)
+      end
     ensure
       tempfile.close
       tempfile.unlink

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -53,9 +53,9 @@ action :apply do
     opts << ['--org', new_resource.org] if new_resource.org
     opts << ['--ring', new_resource.ring] if new_resource.ring
 
+    tempfile = Tempfile.new(['hab_config', '.toml'])
     command = [ 'hab', 'config', 'apply', opts, new_resource.service_group,
                 incarnation, tempfile.path ]
-    tempfile = Tempfile.new(['hab_config', '.toml'])
     begin
       tempfile.write(TOML::Generator.new(new_resource.config).body)
       tempfile.close


### PR DESCRIPTION
shell_out_with_timeout + clean_array are baked into the shell_out
API now post-14.3.20

closes #109 