### PR TITLE
provide habitat token when bypassing hab client

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -116,7 +116,9 @@ class Chef
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
               url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
-              Chef::JSONCompat.parse(http.get(url))
+              Chef::JSONCompat.parse(http.get(url, {
+                Authorization: "Bearer #{ENV['HAB_AUTH_TOKEN']}"
+              }))
             rescue Net::HTTPServerException
               nil
             end

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -116,9 +116,7 @@ class Chef
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
               url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
-              Chef::JSONCompat.parse(http.get(url, {
-                Authorization: "Bearer #{ENV['HAB_AUTH_TOKEN']}"
-              }))
+              Chef::JSONCompat.parse(http.get(url, Authorization: "Bearer #{ENV['HAB_AUTH_TOKEN']}"))
             rescue Net::HTTPServerException
               nil
             end


### PR DESCRIPTION
Signed-off-by: steve <steve.hummingbird@yandex.com>

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the
best of my knowledge, is covered under an appropriate open
source license and I have the right under that license to
submit that work with modifications, whether created in whole
or in part by me, under the same open source license (unless
I am permitted to submit under a different license), as
Indicated in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including
all personal information I submit with it, including my
sign-off) is maintained indefinitely and may be redistributed
consistent with this project or the open source license(s)
involved.

### Description

When a plain http client is used, the HAB_AUTH_TOKEN environment variable is not picked up. This leads to issues when trying to install private packages, as the provider is under the impression that the package does not exist, which causes installing private packages to fail.

### Issues Resolved

This partly resolves #102 
Most likely modifications to the init scripts are needed as well in order to make dealing with private packages work reliably. 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>