### PR TITLE
Updated cookbook for habitat API post 0.56.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ env:
   - INSTANCE=config-ubuntu-1604
   - INSTANCE=config-centos-6
   - INSTANCE=config-centos-7
+  - INSTANCE=user-toml-ubuntu-1404
+  - INSTANCE=user-toml-ubuntu-1604
+  - INSTANCE=user-toml-centos-6
+  - INSTANCE=user-toml-centos-7
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 
 ### hab_package
 
-Install the specified Habitat package. Requires that Habitat is installed
+Install the specified Habitat package from builder. Requires that Habitat is installed
 
 #### actions
 
@@ -89,6 +89,7 @@ Install the specified Habitat package. Requires that Habitat is installed
 - `version`: A Habitat version which contains the version and optionally a release separated by `/`, for example, `3.2.3` or `3.2.3/20160920131015`
 - `bldr_url`: The habitat builder url where packages will be downloaded from (defaults to public habitat builder)
 - `channel`: The release channel to install from (defaults to `stable`)
+- `auth_token`: Auth token for installing a package from a private organization on builder
 
 While it is valid to pass the version and release with a Habitat package as a fully qualified package identifier when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
 
@@ -117,30 +118,29 @@ _Note:_ Applications may run as a specific user. Often with Habitat, the default
 
 - `:load`: (default action) runs `hab service load` to load and start the specified application service
 - `:unload`: runs `hab service unload` to unload and stop the specified application service
+- `:reload`: runs the `:unload` and then `:load` actions
 - `:start`: runs `hab service start` to start the specified application service
 - `:stop`: runs `hab service stop` to stop the specified application service
+- `:restart`: runs the `:stop` and then `:start` actions
 
 #### Properties
 
-Some properties are only valid for `start` or `load` actions. See the description of each option for indication which action(s) the property is used. This is because the underlying `hab sup` commands have different options available in their context.
+The remote_sup property is valid for all actions.
+
+- `remote_sup`: **Advanced Use** Address for remote supervisor. This replaces `--override-name` now that hab purely communicates over TCP. This may specify an alternate local port or a remote supervisor
+
+The follow properties are valid for the `load` action.
 
 - `service_name`: name property, the name of the service, must be in the form of `origin/name`
 - `loaded`: state property indicating whether the service is loaded in the supervisor
 - `running`: state property indicating whether the service is running in the supervisor
-- `permanent_peer`: Only valid for `:start` action, passes `--permanent-peer` to the hab command
-- `listen_gossip`: Only valid for `:start` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
-- `listen_http`: Only valid for `:start` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
-- `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
-- `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command
-- `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
-- `strategy`: Only valid for `:start` or `:load` actions, passes `--strategy` with the specified update strategy to the hab command
-- `topology`: Only valid for `:start` or `:load` actions, passes `--topology` with the specified service topology to the hab command
-- `bldr_url`: Only valid for `:start` or `:load` actions, passes `--url` with the specified Builder URL to the hab command. For local repos, use 'local'.
-- `bind`: Only valid for `:start` or `:load` actions, passes `--bind` with the specified services to bind to the hab command
-- `service_group`: Only valid for `:start` or `:load` actions, passes `--group` with the specified service group to the hab command
-- `config_from`: Only valid for `:start` action, passes `--config-from` with the specified directory to the hab command
-- `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
-- `channel`: Only valid for `:start` or `:load` actions, passes `--channel` with the specified channel to the hab command
+- `strategy`: Passes `--strategy` with the specified update strategy to the hab command
+- `topology`: Passes `--topology` with the specified service topology to the hab command
+- `bldr_url`: Passes `--url` with the specified Builder URL to the hab command.
+- `channel`: Passes `--channel` with the specified channel to the hab command
+- `bind`: Passes `--bind` with the specified services to bind to the hab command
+- `binding_mode`: Passes `--binding-mode` with the specified binding mode. Defaults to `:strict`. Options are `:strict` or `:relaxed`
+- `service_group`: Passes `--group` with the specified service group to the hab command
 
 #### Examples
 
@@ -179,7 +179,7 @@ hab_service 'acme/apps'
 
 Runs a Habitat Supervisor for one or more Habitat Services. It is used in conjunction with `hab_service` which will manage the services loaded and started within the supervisor.
 
-The `run` action handles installing Habitat using the `hab_install` resource, ensures that the `core/hab-sup` package is installed using `hab_package`, and then drops off the appropriate init system definitions and manages the service.
+The `run` action handles installing Habitat using the `hab_install` resource, ensures that the appropriate versions of the `core/hab-sup` and `core/hab-launcher` packages are installed using `hab_package`, and then drops off the appropriate init system definitions and manages the service.
 
 #### Actions
 
@@ -188,14 +188,16 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 #### Properties
 
 - `bldr_url`: The Builder URL for the `hab_package` resource, if needed
-- `permanent_peer`: Only valid for `:start` action, passes `--permanent-peer` to the hab command
-- `listen_gossip`: Only valid for `:start` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
-- `listen_http`: Only valid for `:start` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
-- `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
-- `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command
-- `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
+- `permanent_peer`: Only valid for `:run` action, passes `--permanent-peer` to the hab command
+- `listen_ctl`: Only valid for `:run` action, passes `--listen-ctl` with the specified address and port, e.g., `0.0.0.0:9632`, to the hab command
+- `listen_gossip`: Only valid for `:run` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
+- `listen_http`: Only valid for `:run` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
+- `org`: Only valid for `:run` action, passes `--org` with the specified org name to the hab command
+- `peer`: Only valid for `:run` action, passes `--peer` with the specified initial peer to the hab command
+- `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
+- `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
 
 #### Examples
 
@@ -232,11 +234,8 @@ Applies a given configuration to a habitat service using `hab config apply`.
 
 - `service_group`: The service group to apply the configuration to, for example, `nginx.default`
 - `config`: The configuration to apply as a ruby hash, for example, `{ worker_count: 2, http: { keepalive_timeout: 120 } }`
-- `org`: (optional) passes the `--org` option with the specified org name to the hab config command.
-- `peer`: (optional) passes the `--peer` option with the specified peer to the hab config command.
-- `ring`: (optional) passes the `--ring` option with the specified ring key name to the hab config command.
-- `api_host`: Hostname for the habitat api in order to look up the existing configuration. Defaults to `127.0.0.1`.
-- `api_port`: Port number for the habitat api. Defaults to `9631`.
+- `remote_sup`: **Advanced Use** Address for remote supervisor. This replaces `--override-name` now that hab purely communicates over TCP. This may specify an alternate local port or a remote supervisor
+- `user`: Name of user key to use for encryption. Passes `--user` to `hab config apply`
 
 #### Notes
 
@@ -246,6 +245,33 @@ The version number of the configuration is automatically generated and will be t
 
 ```ruby
 hab_config 'nginx.default' do
+  config({
+    worker_count: 2,
+    http: {
+      keepalive_timeout: 120
+    }
+  })
+end
+```
+
+### hab_user_toml
+
+Templates a user.toml for the specified service. This is written to `/hab/user/<service_name>/config/user.toml`. User.toml can be used to set configuration overriding the default.toml for a given package as an alternative to applying service group level configuration.
+
+#### Actions
+
+- `create`: (default action) Create the user.toml from the specified config.
+- `delete`: Delete the user.toml
+
+#### Properties
+
+- `service_name`: The service group to apply the configuration to, for example, `nginx.default`
+- `config`: Only valid for `:create` action. The configuration to apply as a ruby hash, for example, `{ worker_count: 2, http: { keepalive_timeout: 120 } }`
+
+#### Examples
+
+```ruby
+hab_user_toml 'nginx' do
   config({
     worker_count: 2,
     http: {

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -30,3 +30,5 @@ suites:
     run_list: test::sup
   - name: config
     run_list: test::config
+  - name: user-toml
+    run_list: test::user_toml

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -122,7 +122,7 @@ class Chef
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
               url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
-              Chef::JSONCompat.parse(http.get(url))
+              Chef::JSONCompat.parse(http.get(url, Authorization: "Bearer #{new_resource.auth_token}"))
             rescue Net::HTTPServerException
               nil
             end

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -50,6 +50,9 @@ class Chef
         # - hab pkg list (localinfo?) lamont-granquist/ruby/2.3.1/20160101010101
         #   ^^^^^ need a better name
         #
+        # Probably also want to support installation of local packages
+        # Service resource supports running services from locally installed packages
+        # But we provide no way to handle installation
 
         def load_current_resource
           @current_resource = Chef::Resource::HartPackage.new(new_resource.name)
@@ -63,7 +66,10 @@ class Chef
 
         def install_package(names, versions)
           names.zip(versions).map do |n, v|
-            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url, "#{strip_version(n)}/#{v}", new_resource.options)
+            opts = ['pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url]
+            opts += ['--auth', new_resource.auth_token] if new_resource.auth_token
+            opts += ["#{strip_version(n)}/#{v}", new_resource.options]
+            hab(opts)
           end
         end
 
@@ -129,7 +135,7 @@ class Chef
 
         def http
           # FIXME: use SimpleJSON when the depot mime-type is fixed
-          @http ||= Chef::HTTP::Simple.new('https://willem.habitat.sh/')
+          @http ||= Chef::HTTP::Simple.new('https://bldr.habitat.sh/')
         end
 
         def candidate_versions

--- a/libraries/resource_hab_package.rb
+++ b/libraries/resource_hab_package.rb
@@ -24,8 +24,9 @@ class Chef
       resource_name :hab_package
       provides :hab_package
 
-      property :bldr_url, String, regex: /.*/, default: 'https://willem.habitat.sh'
+      property :bldr_url, String, regex: /.*/, default: 'https://bldr.habitat.sh'
       property :channel, String, default: 'stable'
+      property :auth_token, String
     end
   end
 end

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -26,6 +26,7 @@ class Chef
 
       property :bldr_url, String
       property :permanent_peer, [true, false], default: false
+      property :listen_ctl, String
       property :listen_gossip, String
       property :listen_http, String
       property :override_name, String, default: 'default'
@@ -34,6 +35,7 @@ class Chef
       property :ring, String
       property :hab_channel, String
       property :auto_update, [true, false], default: false
+      property :auth_token, String
 
       action :run do
         hab_install new_resource.name do
@@ -42,13 +44,31 @@ class Chef
 
         hab_package 'core/hab-sup' do
           bldr_url new_resource.bldr_url if new_resource.bldr_url
+          version hab_version
+        end
+
+        hab_package 'core/hab-launcher' do
+          bldr_url new_resource.bldr_url if new_resource.bldr_url
+          version launcher_version
         end
       end
 
       action_class do
+        HAB_VERSION = '0.59.0'.freeze
+        LINUX_LAUNCHER_VERSION = '7797'.freeze
+
+        def hab_version
+          HAB_VERSION
+        end
+
+        def launcher_version
+          LINUX_LAUNCHER_VERSION
+        end
+
         def exec_start_options
           opts = []
           opts << '--permanent-peer' if new_resource.permanent_peer
+          opts << "--listen-ctl #{new_resource.listen_ctl}" if new_resource.listen_ctl
           opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
           opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http
           opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'

--- a/libraries/resource_hab_sup_systemd.rb
+++ b/libraries/resource_hab_sup_systemd.rb
@@ -33,9 +33,10 @@ class Chef
                     Description: 'The Habitat Supervisor',
                   },
                   Service: {
+                    Environment: ("HAB_AUTH_TOKEN=#{new_resource.auth_token}" if new_resource.auth_token),
                     ExecStart: "/bin/hab sup run #{exec_start_options}",
                     Restart: 'on-failure',
-                  },
+                  }.compact,
                   Install: {
                     WantedBy: 'default.target',
                   })
@@ -44,6 +45,8 @@ class Chef
 
         service "hab-sup-#{new_resource.override_name}" do
           subscribes :restart, "systemd_unit[hab-sup-#{new_resource.override_name}.service]"
+          subscribes :restart, 'hab_package[core/hab-sup]'
+          subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
         end
       end

--- a/libraries/resource_hab_sup_sysvinit.rb
+++ b/libraries/resource_hab_sup_sysvinit.rb
@@ -36,12 +36,15 @@ class Chef
           group 'root'
           mode '0755'
           variables(name: "hab-sup-#{new_resource.override_name}",
-                    exec_start_options: exec_start_options)
+                    exec_start_options: exec_start_options,
+                    auth_token: new_resource.auth_token)
           action :create
         end
 
         service "hab-sup-#{new_resource.override_name}" do
           subscribes :restart, "template[/etc/init.d/hab-sup-#{new_resource.override_name}]"
+          subscribes :restart, 'hab_package[core/hab-sup]'
+          subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
         end
       end

--- a/libraries/resource_hab_sup_upstart.rb
+++ b/libraries/resource_hab_sup_upstart.rb
@@ -35,7 +35,8 @@ class Chef
           owner 'root'
           group 'root'
           mode '0644'
-          variables exec_start_options: exec_start_options
+          variables(exec_start_options: exec_start_options,
+                    auth_token: new_resource.auth_token)
           action :create
         end
 
@@ -43,6 +44,8 @@ class Chef
           # RHEL 6 includes Upstart but Chef won't use it unless we specify the provider.
           provider Chef::Provider::Service::Upstart
           subscribes :restart, "template[/etc/init/hab-sup-#{new_resource.override_name}.conf]"
+          subscribes :restart, 'hab_package[core/hab-sup]'
+          subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
         end
       end

--- a/resources/user_toml.rb
+++ b/resources/user_toml.rb
@@ -1,0 +1,49 @@
+# Copyright:: 2017-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'toml'
+
+resource_name :hab_user_toml
+
+property :config, Mash,
+         required: true,
+         coerce: proc { |m| m.is_a?(Hash) ? Mash.new(m) : m }
+property :service_name, String, name_property: true, desired_state: false
+
+action :create do
+  config_directory = "/hab/user/#{new_resource.service_name}/config"
+
+  directory config_directory do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    recursive true
+  end
+
+  file "#{config_directory}/user.toml" do
+    mode '0600'
+    owner 'root'
+    group 'root'
+    content TOML::Generator.new(new_resource.config).body
+    sensitive true
+  end
+end
+
+action :delete do
+  file "/hab/user/#{new_resource.service_name}/config/user.toml" do
+    sensitive true
+    action :delete
+  end
+end

--- a/templates/sysvinit/hab-sup-debian.erb
+++ b/templates/sysvinit/hab-sup-debian.erb
@@ -51,6 +51,11 @@ stop() {
 
 case "$1" in
   start)
+    <% if @auth_token %>
+    log_daemon_msg "Setting HAB_AUTH_TOKEN for $DESC" "$NAME"
+    export HAB_AUTH_TOKEN=<%= @auth_token %>
+    <% end %>
+
     log_daemon_msg "Starting $DESC" "$NAME"
     if running; then
       log_progress_msg "already running ($(pid))"

--- a/templates/upstart/hab-sup.conf.erb
+++ b/templates/upstart/hab-sup.conf.erb
@@ -6,6 +6,10 @@ stop on runlevel [!2345]
 respawn
 respawn limit 5 30
 
+<% if @auth_token %>
+env HAB_AUTH_TOKEN=<%= @auth_token %>
+<% end %>
+
 script
     exec /bin/hab sup run <%= @exec_start_options %>
 end script

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -23,3 +23,18 @@ ruby_block 'wait-for-sup-chef-es-startup' do
   retries 30
   retry_delay 1
 end
+
+hab_sup 'test-auth-token' do
+  auth_token 'test'
+  override_name 'auth-token'
+  listen_http '0.0.0.0:10001'
+  listen_gossip '0.0.0.0:10000'
+end
+
+ruby_block 'wait-for-sup-test-auth-token-startup' do
+  block do
+    raise unless File.exist?('/hab/sup/auth-token/data/services.dat')
+  end
+  retries 30
+  retry_delay 1
+end

--- a/test/integration/user-toml/default_spec.rb
+++ b/test/integration/user-toml/default_spec.rb
@@ -1,0 +1,27 @@
+describe user('hab') do
+  it { should exist }
+end
+
+describe file('/bin/hab') do
+  it { should exist }
+  it { should be_symlink }
+end
+
+# This needs to be updated each time Habitat is released so we ensure we're getting the version
+# required by this cookbook.
+describe command('hab -V') do
+  its('stdout') { should match(%r{^hab 0.59.0/}) }
+  its('exit_status') { should eq 0 }
+end
+
+nginx_content = <<-EOF
+worker_processes = 2
+
+[http]
+keepalive_timeout = 120
+EOF
+
+describe file('/hab/user/nginx/config/user.toml') do
+  it { should exist }
+  its('content') { should match(nginx_content) }
+end


### PR DESCRIPTION
### Description

- Added hab_user_toml resource for templating user.toml
- Added auth token support for private organizations
  - auth_token is passed ont he command line for a package install
  - HAB_AUTH_TOKEN is templated into the service definition for the supervisor if specified
- Remove invalid Habitat API options that no longer apply since Habitat 0.56.0
- Added listen_ctl option for hab_sup resource
- Added remote_sup option for communication with non-default supervisor
- Locked supervisor version to hab version
- Set launcher version to make sure it is updated appropriately for hab sup
- Set the supervisor service to restart if hab-sup or hab-launcher package resources change
- Removed validation of channel name, as channels can be arbitrarily created on bldr
- Expanded testing to cover changes
- Updated readme

### Issues Resolved

This closes #106 
This closes #102 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
