### PR TITLE
Refactor hab_service resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,30 +118,29 @@ _Note:_ Applications may run as a specific user. Often with Habitat, the default
 
 - `:load`: (default action) runs `hab service load` to load and start the specified application service
 - `:unload`: runs `hab service unload` to unload and stop the specified application service
+- `:reload`: runs the `:unload` and then `:load` actions
 - `:start`: runs `hab service start` to start the specified application service
 - `:stop`: runs `hab service stop` to stop the specified application service
+- `:restart`: runs the `:stop` and then `:start` actions
 
 #### Properties
 
-Some properties are only valid for `start` or `load` actions. See the description of each option for indication as to which action(s) the property is used with. This is because the underlying `hab sup` commands have different options available in their context.
+The remote_sup property is valid for all actions.
+
+- `remote_sup`: **Advanced Use** Address for remote supervisor. This replaces `--override-name` now that hab purely communicates over TCP. This may specify an alternate local port or a remote supervisor
+
+The follow properties are valid for the `load` action.
 
 - `service_name`: name property, the name of the service, must be in the form of `origin/name`
 - `loaded`: state property indicating whether the service is loaded in the supervisor
 - `running`: state property indicating whether the service is running in the supervisor
-- `permanent_peer`: Only valid for `:start` action, passes `--permanent-peer` to the hab command
-- `listen_gossip`: Only valid for `:start` action, passes `--listen-gossip` with the specified address and port, e.g., `0.0.0.0:9638`, to the hab command
-- `listen_http`: Only valid for `:start` action, passes `--listen-http` with the specified address and port, e.g., `0.0.0.0:9631`, to the hab command
-- `org`: Only valid for `:start` action, passes `--org` with the specified org name to the hab command
-- `peer`: Only valid for `:start` action, passes `--peer` with the specified initial peer to the hab command. If an array of multiple peers are specified then a `--peer` flag is added for each.
-- `ring`: Only valid for `:start` action, passes `--ring` with the specified ring key name to the hab command
-- `strategy`: Only valid for `:start` or `:load` actions, passes `--strategy` with the specified update strategy to the hab command
-- `topology`: Only valid for `:start` or `:load` actions, passes `--topology` with the specified service topology to the hab command
-- `bldr_url`: Only valid for `:start` or `:load` actions, passes `--url` with the specified Builder URL to the hab command. For local repos, use 'local'.
-- `bind`: Only valid for `:start` or `:load` actions, passes `--bind` with the specified services to bind to the hab command. If an array of multiple service binds are specified then a `--bind` flag is added for each.
-- `service_group`: Only valid for `:start` or `:load` actions, passes `--group` with the specified service group to the hab command
-- `config_from`: Only valid for `:start` action, passes `--config-from` with the specified directory to the hab command
-- `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
-- `channel`: Only valid for `:start` or `:load` actions, passes `--channel` with the specified channel to the hab command
+- `strategy`: Passes `--strategy` with the specified update strategy to the hab command
+- `topology`: Passes `--topology` with the specified service topology to the hab command
+- `bldr_url`: Passes `--url` with the specified Builder URL to the hab command.
+- `channel`: Passes `--channel` with the specified channel to the hab command
+- `bind`: Passes `--bind` with the specified services to bind to the hab command. If an array of multiple service binds are specified then a `--bind` flag is added for each.
+- `binding_mode`: Passes `--binding-mode` with the specified binding mode. Defaults to `:strict`. Options are `:strict` or `:relaxed`
+- `service_group`: Passes `--group` with the specified service group to the hab command
 
 #### Examples
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -20,25 +20,19 @@ property :service_name, String, name_property: true
 property :loaded, [true, false], default: false, desired_state: true
 property :running, [true, false], default: false, desired_state: true
 
-# hab sup options which get included based on the action of the resource
-property :permanent_peer, [true, false], default: false
-property :listen_gossip, String
-property :listen_http, String, desired_state: false
-property :org, String, default: 'default'
-property :peer, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
-property :ring, String
+# hab svc options which get included based on the action of the resource
 property :strategy, String
 property :topology, String
 property :bldr_url, String
+property :channel, [Symbol, String]
 property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
+property :binding_mode, [Symbol, String], equal_to: [:strict, 'strict', :relaxed, 'relaxed'], default: :strict
 property :service_group, String
-property :config_from, String
-property :override_name, String, default: 'default'
-property :channel, [Symbol, String], default: :stable
+property :remote_sup, String
 
 load_current_value do
   running service_up?(service_name)
-  loaded ::File.exist?("/hab/sup/#{override_name}/specs/#{service_name.split('/').last}.spec")
+  loaded service_loaded?(service_name)
 
   Chef::Log.debug("service #{service_name} running state: #{running}")
   Chef::Log.debug("service #{service_name} loaded state: #{loaded}")
@@ -60,8 +54,8 @@ end
 # present and `sup_for_service_name` will be nil and we will get a
 # NoMethodError.
 #
-def service_up?(svc_name)
-  http_uri = listen_http ? "http://#{listen_http}" : 'http://localhost:9631'
+def get_service_details(svc_name)
+  http_uri = remote_sup ? "http://#{remote_sup}" : 'http://localhost:9631'
 
   begin
     TCPSocket.new(URI(http_uri).host, URI(http_uri).port).close
@@ -77,9 +71,13 @@ def service_up?(svc_name)
     return false
   end
 
-  sup_for_service_name = svcs.find do |s|
+  svcs.find do |s|
     [s['spec_ident']['origin'], s['spec_ident']['name']].join('/') =~ /#{svc_name}/
   end
+end
+
+def service_up?(svc_name)
+  sup_for_service_name = get_service_details(svc_name)
 
   begin
     sup_for_service_name['process']['state'] == 'up'
@@ -89,21 +87,40 @@ def service_up?(svc_name)
   end
 end
 
+def service_loaded?(svc_name)
+  sup_for_service_name = get_service_details(svc_name)
+
+  if sup_for_service_name
+    true
+  else
+    false
+  end
+end
+
+# TODO: Load should detect if options such as bldr_url, channel, binds, etc have changed and reload if they have
 action :load do
-  execute "hab svc load #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.loaded
+  execute "hab svc load #{new_resource.service_name} #{svc_options.join(' ')}" unless current_resource.loaded
 end
 
 action :unload do
-  execute "hab svc unload #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.loaded
+  execute "hab svc unload #{new_resource.service_name} #{svc_options.join(' ')}" if current_resource.loaded
 end
 
 action :start do
-  action_load
-  execute "hab svc start #{new_resource.service_name} #{sup_options.join(' ')}" unless current_resource.running
+  # FIXME: Should we do this, which matches the expected Hab workflow, or call action_load?
+  unless current_resource.loaded
+    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded in the Habitat supervisor")
+    raise
+  end
+  execute "hab svc start #{new_resource.service_name} #{svc_options.join(' ')}" unless current_resource.running
 end
 
 action :stop do
-  execute "hab svc stop #{new_resource.service_name} #{sup_options.join(' ')}" if current_resource.running
+  unless current_resource.loaded
+    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded in the Habitat supervisor")
+    raise
+  end
+  execute "hab svc stop #{new_resource.service_name} #{svc_options.join(' ')}" if current_resource.running
 end
 
 action :restart do
@@ -119,36 +136,22 @@ action :reload do
 end
 
 action_class do
-  def sup_options
+  def svc_options
     opts = []
 
-    # certain options are only valid for specific `hab sup` subcommands.
+    # certain options are only valid for specific `hab svc` subcommands.
     case action
     when :load
       opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
-      unless new_resource.bldr_url == 'local'
-        opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
-        opts << "--channel #{new_resource.channel}"
-      end
+      opts << "--binding-mode #{new_resource.binding_mode}"
+      opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
+      opts << "--channel #{new_resource.channel}" if new_resource.channel
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
-    when :start, :stop
-      opts << '--permanent-peer' if new_resource.permanent_peer
-      opts.push(*new_resource.bind.map { |b| "--bind #{b}" }) if new_resource.bind
-      opts << "--config-from #{new_resource.config_from}" if new_resource.config_from
-      unless new_resource.bldr_url == 'local'
-        opts << "--url #{new_resource.bldr_url}" if new_resource.bldr_url
-      end
-      opts << "--group #{new_resource.service_group}" if new_resource.service_group
-      opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
-      opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http
-      opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
-      opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
-      opts << "--ring #{new_resource.ring}" if new_resource.ring
     end
 
-    opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'
+    opts << "--remote-sup #{new_resource.remote_sup}" if new_resource.remote_sup
 
     opts.map(&:split).flatten.compact
   end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -33,18 +33,6 @@ describe 'test::service' do
       )
     end
 
-    it 'loads a service with a single peer' do
-      expect(chef_run).to load_hab_service('core/rabbitmq').with(
-        peer: ['127.0.0.2']
-      )
-    end
-
-    it 'loads a service with multiple peers' do
-      expect(chef_run).to load_hab_service('core/sensu').with(
-        peer: ['127.0.0.2', '127.0.0.3']
-      )
-    end
-
     it 'loads a service with a single bind' do
       expect(chef_run).to load_hab_service('core/ruby-rails-sample').with(
         bind: [

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -60,7 +60,7 @@ end
 hab_package 'core/memcached'
 hab_service 'core/memcached'
 
-# Test Peers and Binds
+# Test Binds
 
 # Single string bind
 hab_package 'core/ruby-rails-sample'
@@ -68,19 +68,12 @@ hab_service 'core/ruby-rails-sample' do
   bind 'database:postgresql.default'
 end
 
-# Single string peer
+# Multiple  binds
 hab_package 'core/rabbitmq'
-hab_service 'core/rabbitmq' do
-  peer '127.0.0.2'
-end
+hab_service 'core/rabbitmq'
 
-# Multiple peers and binds
 hab_package 'core/sensu'
 hab_service 'core/sensu' do
-  peer [
-    '127.0.0.2',
-    '127.0.0.3',
-  ]
   bind [
     'rabbitmq:rabbitmq.default',
     'redis:redis.default',


### PR DESCRIPTION
### Description

Remove invalid Habitat API options that no longer apply since Habitat 0.56.0
Added remote_sup option for communication with non-default supervisor

This breaks out service changes from #115 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
