### PR TITLE
Added auth token support to package resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 
 ### hab_package
 
-Install the specified Habitat package. Requires that Habitat is installed
+Install the specified Habitat package from builder. Requires that Habitat is installed
 
 #### actions
 
@@ -89,6 +89,7 @@ Install the specified Habitat package. Requires that Habitat is installed
 - `version`: A Habitat version which contains the version and optionally a release separated by `/`, for example, `3.2.3` or `3.2.3/20160920131015`
 - `bldr_url`: The habitat builder url where packages will be downloaded from (defaults to public habitat builder)
 - `channel`: The release channel to install from (defaults to `stable`)
+- `auth_token`: Auth token for installing a package from a private organization on builder
 
 While it is valid to pass the version and release with a Habitat package as a fully qualified package identifier when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
 

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -50,6 +50,9 @@ class Chef
         # - hab pkg list (localinfo?) lamont-granquist/ruby/2.3.1/20160101010101
         #   ^^^^^ need a better name
         #
+        # Probably also want to support installation of local packages
+        # Service resource supports running services from locally installed packages
+        # But we provide no way to handle installation
 
         def load_current_resource
           @current_resource = Chef::Resource::HartPackage.new(new_resource.name)
@@ -63,7 +66,10 @@ class Chef
 
         def install_package(names, versions)
           names.zip(versions).map do |n, v|
-            hab('pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url, "#{strip_version(n)}/#{v}", new_resource.options)
+            opts = ['pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url]
+            opts += ['--auth', new_resource.auth_token] if new_resource.auth_token
+            opts += ["#{strip_version(n)}/#{v}", new_resource.options]
+            hab(opts)
           end
         end
 
@@ -116,7 +122,11 @@ class Chef
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
               url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
-              Chef::JSONCompat.parse(http.get(url))
+
+              headers = {}
+              headers['Authorization'] = "Bearer #{new_resource.auth_token}" if new_resource.auth_token
+
+              Chef::JSONCompat.parse(http.get(url, headers))
             rescue Net::HTTPServerException
               nil
             end
@@ -129,7 +139,7 @@ class Chef
 
         def http
           # FIXME: use SimpleJSON when the depot mime-type is fixed
-          @http ||= Chef::HTTP::Simple.new('https://willem.habitat.sh/')
+          @http ||= Chef::HTTP::Simple.new('https://bldr.habitat.sh/')
         end
 
         def candidate_versions

--- a/libraries/resource_hab_package.rb
+++ b/libraries/resource_hab_package.rb
@@ -24,8 +24,9 @@ class Chef
       resource_name :hab_package
       provides :hab_package
 
-      property :bldr_url, String, regex: /.*/, default: 'https://willem.habitat.sh'
+      property :bldr_url, String, regex: /.*/, default: 'https://bldr.habitat.sh'
       property :channel, String, default: 'stable'
+      property :auth_token, String
     end
   end
 end


### PR DESCRIPTION
### Description

Added auth token support to package resource
Set default bldr url to bldr.habitat.sh

This breaks out package resource changes from #115 

### Issues Resolved

This closes #102 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
