### PR TITLE
Change expeditor notification channel

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,5 @@
 slack:
-  notify_channel: ops
+  notify_channel: ops-notify
 
 merge_actions:
   - built_in:update_changelog:


### PR DESCRIPTION
Notifications now go to #ops-notify in slack. This just changes the relevant expeditor configuration to send notifications to the correct channel.