### PR TITLE
Add binlink property to hab_package resource.  Closes #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Install the specified Habitat package from builder. Requires that Habitat is ins
 - `bldr_url`: The habitat builder url where packages will be downloaded from (defaults to public habitat builder)
 - `channel`: The release channel to install from (defaults to `stable`)
 - `auth_token`: Auth token for installing a package from a private organization on builder
+- `binlink`: If habitat should attempt to binlink the package.  Acceptable values: `true`, `false`, `:force`.  Will faill on binlinking if set to `true` and binary or binlink exists.
+- `options`: Pass any additional parameters to the habitat install command.
 
 While it is valid to pass the version and release with a Habitat package as a fully qualified package identifier when using the `hab` CLI, they must be specified using the `version` property when using this resource. See the examples below.
 
@@ -105,6 +107,14 @@ end
 
 hab_package 'core/redis' do
   version '3.2.3/20160920131015'
+end
+
+hab_package 'core/nginx' do
+  binlink :force
+end
+
+hab_package 'core/nginx' do
+  options '--binlink'
 end
 ```
 

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -69,6 +69,8 @@ class Chef
             opts = ['pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url]
             opts += ['--auth', new_resource.auth_token] if new_resource.auth_token
             opts += ["#{strip_version(n)}/#{v}", new_resource.options]
+            opts += ['--binlink'] if new_resource.auth_token
+            opts += ['--force'] if new_resource.auth_token.eql? :force
             hab(opts)
           end
         end

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -69,8 +69,8 @@ class Chef
             opts = ['pkg', 'install', '--channel', new_resource.channel, '--url', new_resource.bldr_url]
             opts += ['--auth', new_resource.auth_token] if new_resource.auth_token
             opts += ["#{strip_version(n)}/#{v}", new_resource.options]
-            opts += ['--binlink'] if new_resource.auth_token
-            opts += ['--force'] if new_resource.auth_token.eql? :force
+            opts += ['--binlink'] if new_resource.binlink
+            opts += ['--force'] if new_resource.binlink.eql? :force
             hab(opts)
           end
         end

--- a/libraries/resource_hab_package.rb
+++ b/libraries/resource_hab_package.rb
@@ -27,6 +27,7 @@ class Chef
       property :bldr_url, String, regex: /.*/, default: 'https://bldr.habitat.sh'
       property :channel, String, default: 'stable'
       property :auth_token, String
+      property :binlink, equal_to: [true, false, :force], default: false
     end
   end
 end

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -28,9 +28,19 @@ describe 'test::package' do
         .with(bldr_url: 'https://bldr.acceptance.habitat.sh')
     end
 
-    it 'installs core/htop with binlink' do
+    it 'installs core/htop with binlink option' do
       expect(chef_run).to install_hab_package('core/htop')
         .with(options: ['--binlink'])
+    end
+
+    it 'installs core/foo with binlink parameters' do
+      expect(chef_run).to install_hab_package('binlink')
+        .with(binlink: true)
+    end
+
+    it 'installs core/foo by forcing binlink' do
+      expect(chef_run).to install_hab_package('binlink_force')
+        .with(binlink: :force)
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -25,3 +25,13 @@ hab_package 'core/hab-sup' do
   # us from doing our tests, so ignore failures.
   ignore_failure true
 end
+
+hab_package 'binlink' do
+  package_name 'core/binlink'
+  binlink true
+end
+
+hab_package 'binlink_force' do
+  package_name 'core/binlink'
+  binlink :force
+end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -27,11 +27,12 @@ hab_package 'core/hab-sup' do
 end
 
 hab_package 'binlink' do
-  package_name 'core/binlink'
+  package_name 'core/nginx'
+  version '1.15.2'
   binlink true
 end
 
 hab_package 'binlink_force' do
-  package_name 'core/binlink'
+  package_name 'core/nginx'
   binlink :force
 end

--- a/test/fixtures/cookbooks/test/recipes/package.rb
+++ b/test/fixtures/cookbooks/test/recipes/package.rb
@@ -34,5 +34,6 @@ end
 
 hab_package 'binlink_force' do
   package_name 'core/nginx'
+  version '1.15.3/20180914151930'
   binlink :force
 end

--- a/test/integration/package/default_spec.rb
+++ b/test/integration/package/default_spec.rb
@@ -45,3 +45,8 @@ describe file('/bin/htop') do
   it { should be_symlink }
   its(:link_path) { should match(%r{/hab/pkgs/core/htop}) }
 end
+
+describe file('/bin/nginx') do
+  it { should be_symlink }
+  its(:link_path) { should match(%r{/hab/pkgs/core/nginx/1.15.3/20180914151930}) }
+end


### PR DESCRIPTION
### Description

This change adds a `binlink` propert to the `hab_package` resource to allow consumers of the custom resource to declare `binlink`ing in an idiomatic way.

### Issues Resolved

#138 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
