### PR TITLE
fix incorrect documentation for hab_package action

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Install the specified Habitat package from builder. Requires that Habitat is ins
 #### actions
 
 - `install`: installs the specified package
-- `upgrade`: aliased to install
+- `upgrade`: installs the specified package. If a newer version is available in the configured channel, upgrades to that version
 
 #### Properties
 


### PR DESCRIPTION
### Description

corrects incorrect description of the update action of the hab_package resource. Install action does not update an already installed package. Update however does.

**Obvious fix.**

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>