### PR TITLE
removed override_name and added service stop action

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ _Note:_ Applications may run as a specific user. Often with Habitat, the default
 
 The remote_sup property is valid for all actions.
 
-- `remote_sup`: **Advanced Use** Address for remote supervisor. This replaces `--override-name` now that hab purely communicates over TCP. This may specify an alternate local port or a remote supervisor
+- `remote_sup`: Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
 
 The follow properties are valid for the `load` action.
 
@@ -196,7 +196,6 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 - `peer`: Only valid for `:run` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
-- `override_name`: **Advanced Use** Valid for all actions, passes `--override-name` with the specified name to the hab command; used for running services in multiple supervisors
 - `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
 
 #### Examples
@@ -205,10 +204,7 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 # set up with just the defaults
 hab_sup 'default'
 
-# run with an override name, requires changing listen_http and
-# listen_gossip if a default supervisor is running
 hab_sup 'test-options' do
-  override_name 'myapps'
   listen_http '0.0.0.0:9999'
   listen_gossip '0.0.0.0:9998'
 end
@@ -234,7 +230,7 @@ Applies a given configuration to a habitat service using `hab config apply`.
 
 - `service_group`: The service group to apply the configuration to, for example, `nginx.default`
 - `config`: The configuration to apply as a ruby hash, for example, `{ worker_count: 2, http: { keepalive_timeout: 120 } }`
-- `remote_sup`: **Advanced Use** Address for remote supervisor. This replaces `--override-name` now that hab purely communicates over TCP. This may specify an alternate local port or a remote supervisor
+- `remote_sup`: Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
 - `user`: Name of user key to use for encryption. Passes `--user` to `hab config apply`
 
 #### Notes

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -29,7 +29,6 @@ class Chef
       property :listen_ctl, String
       property :listen_gossip, String
       property :listen_http, String
-      property :override_name, String, default: 'default'
       property :org, String, default: 'default'
       property :peer, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
       property :ring, String
@@ -71,7 +70,6 @@ class Chef
           opts << "--listen-ctl #{new_resource.listen_ctl}" if new_resource.listen_ctl
           opts << "--listen-gossip #{new_resource.listen_gossip}" if new_resource.listen_gossip
           opts << "--listen-http #{new_resource.listen_http}" if new_resource.listen_http
-          opts << "--override-name #{new_resource.override_name}" unless new_resource.override_name == 'default'
           opts << "--org #{new_resource.org}" unless new_resource.org == 'default'
           opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
           opts << "--ring #{new_resource.ring}" if new_resource.ring

--- a/libraries/resource_hab_sup_systemd.rb
+++ b/libraries/resource_hab_sup_systemd.rb
@@ -28,7 +28,7 @@ class Chef
       action :run do
         super()
 
-        systemd_unit "hab-sup-#{new_resource.override_name}.service" do
+        systemd_unit 'hab-sup.service' do
           content(Unit: {
                     Description: 'The Habitat Supervisor',
                   },
@@ -43,11 +43,17 @@ class Chef
           action :create
         end
 
-        service "hab-sup-#{new_resource.override_name}" do
-          subscribes :restart, "systemd_unit[hab-sup-#{new_resource.override_name}.service]"
+        service 'hab-sup' do
+          subscribes :restart, 'systemd_unit[hab-sup.service]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
+        end
+      end
+
+      action :stop do
+        service 'hab-sup' do
+          action :stop
         end
       end
     end

--- a/libraries/resource_hab_sup_sysvinit.rb
+++ b/libraries/resource_hab_sup_sysvinit.rb
@@ -29,23 +29,29 @@ class Chef
       action :run do
         super()
 
-        template "/etc/init.d/hab-sup-#{new_resource.override_name}" do
+        template '/etc/init.d/hab-sup' do
           source "sysvinit/hab-sup-#{node['platform_family']}.erb"
           cookbook 'habitat'
           owner 'root'
           group 'root'
           mode '0755'
-          variables(name: "hab-sup-#{new_resource.override_name}",
+          variables(name: 'hab-sup',
                     exec_start_options: exec_start_options,
                     auth_token: new_resource.auth_token)
           action :create
         end
 
-        service "hab-sup-#{new_resource.override_name}" do
-          subscribes :restart, "template[/etc/init.d/hab-sup-#{new_resource.override_name}]"
+        service 'hab-sup' do
+          subscribes :restart, 'template[/etc/init.d/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
+        end
+      end
+
+      action :stop do
+        service 'hab-sup' do
+          action :stop
         end
       end
     end

--- a/libraries/resource_hab_sup_upstart.rb
+++ b/libraries/resource_hab_sup_upstart.rb
@@ -29,7 +29,7 @@ class Chef
       action :run do
         super()
 
-        template "/etc/init/hab-sup-#{new_resource.override_name}.conf" do
+        template '/etc/init/hab-sup.conf' do
           source 'upstart/hab-sup.conf.erb'
           cookbook 'habitat'
           owner 'root'
@@ -40,13 +40,19 @@ class Chef
           action :create
         end
 
-        service "hab-sup-#{new_resource.override_name}" do
+        service 'hab-sup' do
           # RHEL 6 includes Upstart but Chef won't use it unless we specify the provider.
           provider Chef::Provider::Service::Upstart
-          subscribes :restart, "template[/etc/init/hab-sup-#{new_resource.override_name}.conf]"
+          subscribes :restart, 'template[/etc/init/hab-sup.conf]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'
           action [:enable, :start]
+        end
+      end
+
+      action :stop do
+        service 'hab-sup' do
+          action :stop
         end
       end
     end

--- a/spec/unit/sup_spec.rb
+++ b/spec/unit/sup_spec.rb
@@ -10,7 +10,6 @@ describe 'test::sup' do
       it 'runs hab sup with a custom org' do
         expect(chef_run).to run_hab_sup('test-options')
           .with(
-            override_name: 'chef-es',
             listen_http: '0.0.0.0:9999',
             listen_gossip: '0.0.0.0:9998'
           )
@@ -19,7 +18,6 @@ describe 'test::sup' do
       it 'runs hab sup with a auth options' do
         expect(chef_run).to run_hab_sup('test-auth-token')
           .with(
-            override_name: 'auth-token',
             listen_http: '0.0.0.0:10001',
             listen_gossip: '0.0.0.0:10000',
             auth_token: 'test'
@@ -28,7 +26,6 @@ describe 'test::sup' do
 
       it 'run hab sup with a single peer' do
         expect(chef_run).to run_hab_sup('single_peer').with(
-          override_name: 'single_peer',
           peer: ['127.0.0.2']
         )
       end
@@ -36,7 +33,6 @@ describe 'test::sup' do
       it 'runs hab sup with multiple peers' do
         expect(chef_run).to run_hab_sup('multiple_peers')
           .with(
-            override_name: 'multiple_peers',
             peer: ['127.0.0.2', '127.0.0.3']
           )
       end
@@ -106,7 +102,7 @@ describe 'test::sup' do
               Description: 'The Habitat Supervisor',
             },
             Service: {
-              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999 --override-name chef-es',
+              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999',
               Restart: 'on-failure',
             },
             Install: {
@@ -137,7 +133,7 @@ describe 'test::sup' do
             },
             Service: {
               Environment: 'HAB_AUTH_TOKEN=test',
-              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001 --override-name auth-token',
+              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001',
               Restart: 'on-failure',
             },
             Install: {
@@ -212,7 +208,7 @@ describe 'test::sup' do
           group: 'root',
           mode: '0644',
           variables: {
-            exec_start_options: '--listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999 --override-name chef-es',
+            exec_start_options: '--listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999',
             auth_token: nil,
           }
         )
@@ -240,7 +236,7 @@ describe 'test::sup' do
           group: 'root',
           mode: '0644',
           variables: {
-            exec_start_options: '--listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001 --override-name auth-token',
+            exec_start_options: '--listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001',
             auth_token: 'test',
           }
         )
@@ -313,7 +309,7 @@ describe 'test::sup' do
           mode: '0755',
           variables: {
             name: 'hab-sup-chef-es',
-            exec_start_options: '--listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999 --override-name chef-es',
+            exec_start_options: '--listen-gossip 0.0.0.0:9998 --listen-http 0.0.0.0:9999',
             auth_token: nil,
           }
         )
@@ -341,7 +337,7 @@ describe 'test::sup' do
           mode: '0755',
           variables: {
             name: 'hab-sup-auth-token',
-            exec_start_options: '--listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001 --override-name auth-token',
+            exec_start_options: '--listen-gossip 0.0.0.0:10000 --listen-http 0.0.0.0:10001',
             auth_token: 'test',
           }
         )


### PR DESCRIPTION
This change adds support for Supervisor 0.67.0 by:
 • removing the `override_name` from the `hab_sup` resource property
 • adding a `stop` action to the `hab_sup` resource
Signed-off-by: Jeremy J. Miller <jm@chef.io>