### PR TITLE
remove duplicate windows query param

### DIFF
--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -130,7 +130,6 @@ class Chef
               name_version = [pkg_name, version].compact.join('/').squeeze('/').chomp('/').sub(%r{^\/}, '')
               url = "#{new_resource.bldr_url.chomp('/')}/v1/depot/channels/#{origin}/#{new_resource.channel}/pkgs/#{name_version}"
               url << '/latest' unless name_version.count('/') >= 2
-              url << '?target=x86_64-windows' if platform_family?('windows')
               url << "?#{platform_target}" unless platform_target.empty?
 
               headers = {}


### PR DESCRIPTION
Signed-off-by: skylerto <skylerclayne@gmail.com>

### Description

Fixes bug where multiple platform_target query params are attached url.

### Issues Resolved

resolves #155 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
