### PR TITLE
Include version when matching service name

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -74,7 +74,7 @@ def get_service_details(svc_name)
   end
 
   svcs.find do |s|
-    [s['spec_ident']['origin'], s['spec_ident']['name']].join('/') =~ /#{svc_name}/
+    [s['spec_ident']['origin'], s['spec_ident']['name']].join('/') =~ %r{/#{svc_name}/}
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -74,7 +74,7 @@ def get_service_details(svc_name)
   end
 
   svcs.find do |s|
-    [s['spec_ident']['origin'], s['spec_ident']['name']].join('/') =~ %r{/#{svc_name}/}
+    [s['spec_ident']['origin'], s['spec_ident']['name'], s['spec_ident']['version']].join('/') =~ %r{#{svc_name}/}
   end
 end
 

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -68,6 +68,10 @@ hab_service 'core/ruby-rails-sample' do
   bind 'database:postgresql.default'
 end
 
+# Test service name matching
+hab_package 'core/sensu-backend'
+hab_service 'core/sensu-backend'
+
 # Multiple  binds
 hab_package 'core/rabbitmq'
 hab_service 'core/rabbitmq'

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -23,5 +23,14 @@ end
 
 describe file('/hab/sup/default/specs/ruby-rails-sample.spec') do
   it { should exist }
-  its(:content) { should match(/binds = \["database:postgresql.default"\]/) }
+end
+
+describe file('/hab/sup/default/specs/sensu.spec') do
+  it { should exist }
+  its(:content) { should match(/binds = \["rabbitmq:rabbitmq.default", "redis:redis.default"\]/) }
+end
+
+describe file('/hab/sup/default/specs/sensu-backend.spec') do
+  it { should exist }
+  its(:content) { should match(/^desired_state = "up"$/) }
 end


### PR DESCRIPTION
Signed-off-by: gscho <greg.c.schofield@gmail.com>

### Description

The current regular expression matches on service name which causes an issue when another service contains matches.

Ex: I have a loaded service named `jenkins-slave-provisioner` which uses the habitat cookbook to load up a `jenkins-slave` package. Since the current regex matches `jenkins-slave-provisioner` the `jenkins-slave` package is never loaded.

I've wrapped the regular expression in `%r{}` and added a `/` to the end of the pattern. I've also included the version in the source string built from `['spec_ident']` values.

### Issues Resolved

#134 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
