### PR TITLE
Add health check interval option to hab_sup resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Installs Habitat on the system using the [install script](https://raw.githubuser
 - `bldr_url`: Optional URL to an alternate Builder (defaults to the public Builder)
 - `create_user`: Creates the `hab` system user (defaults to `true`)
 - `tmp_dir`: Sets TMPDIR environment variable for location to place temp files.  (required if `/tmp` and `/var/tmp` are mounted `noexec`)
-- `license`: Specifies acceptance of habitat license when set to `accept` (defaults to empty string). 
+- `license`: Specifies acceptance of habitat license when set to `accept` (defaults to empty string).
 
 #### Examples
 
@@ -226,7 +226,8 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
-- `license`: Specifies acceptance of habitat license when set to `accept` (defaults to empty string). 
+- `license`: Specifies acceptance of habitat license when set to `accept` (defaults to empty string).
+- `health_check_interval`: The interval (seconds) on which to run health checks (defaults to 30).
 
 #### Examples
 

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -36,6 +36,7 @@ class Chef
       property :auto_update, [true, false], default: false
       property :auth_token, String
       property :license, String, equal_to: ['accept']
+      property :health_check_interval, coerce: proc { |h| h.is_a?(String) ? h : h.to_s }
 
       action :run do
         hab_install new_resource.name do
@@ -66,6 +67,7 @@ class Chef
           opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
           opts << "--ring #{new_resource.ring}" if new_resource.ring
           opts << '--auto-update' if new_resource.auto_update
+          opts << "--health-check-interval #{new_resource.health_check_interval}" if new_resource.health_check_interval
           opts.join(' ')
         end
       end

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -68,6 +68,23 @@ ruby_block 'wait-for-sup-single_peer-startup' do
   retry_delay 1
 end
 
+hab_sup 'health_check_interval' do
+  license 'accept'
+  health_check_interval 60
+  listen_http '0.0.0.0:7999'
+  listen_gossip '0.0.0.0:7998'
+  notifies :stop, 'hab_sup[single_peer]', :before
+  notifies :delete, 'directory[/hab/sup]', :before
+end
+
+ruby_block 'wait-for-sup-health_check_interval-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
 hab_sup 'multiple_peers' do
   license 'accept'
   peer ['127.0.0.2', '127.0.0.3']


### PR DESCRIPTION
Signed-off-by: gscho <greg.c.schofield@gmail.com>

### Description

Adds the option to specify a health check interval to the hab_sup resource.

### Issues Resolved

#166 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
