### PR TITLE
Add option for Supervisor HTTP gateway authentication token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ env:
   - INSTANCE=service-ubuntu-1804
   - INSTANCE=service-centos-6
   - INSTANCE=service-centos-7
+  - INSTANCE=service-auth-ubuntu-1604
+  - INSTANCE=service-auth-ubuntu-1804
+  - INSTANCE=service-auth-centos-6
+  - INSTANCE=service-auth-centos-7
   - INSTANCE=sup-ubuntu-1604
   - INSTANCE=sup-ubuntu-1804
   - INSTANCE=sup-centos-6
@@ -32,6 +36,10 @@ env:
   - INSTANCE=config-ubuntu-1804
   - INSTANCE=config-centos-6
   - INSTANCE=config-centos-7
+  - INSTANCE=config-auth-ubuntu-1604
+  - INSTANCE=config-auth-ubuntu-1804
+  - INSTANCE=config-auth-centos-6
+  - INSTANCE=config-auth-centos-7
   - INSTANCE=user-toml-ubuntu-1604
   - INSTANCE=user-toml-ubuntu-1804
   - INSTANCE=user-toml-centos-6

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The remote_sup property is valid for all actions.
 
 - `remote_sup`: Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
 - `remote_sup_http`: Address for remote supervisor http port. Used to pull existing configuration data. If this is invalid, config will be applied on every Chef run.
+- `gateway_auth_token`: Auth token for accessing the remote supervisor's http port.
 
 The follow properties are valid for the `load` action.
 
@@ -226,6 +227,7 @@ The `run` action handles installing Habitat using the `hab_install` resource, en
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
+- `gateway_auth_token`: Auth token for accessing the supervisor's HTTP gateway. This value is templated into the appropriate service file.
 - `license`: Specifies acceptance of habitat license when set to `accept` (defaults to empty string).
 - `health_check_interval`: The interval (seconds) on which to run health checks (defaults to 30).
 
@@ -263,6 +265,7 @@ Applies a given configuration to a habitat service using `hab config apply`.
 - `config`: The configuration to apply as a ruby hash, for example, `{ worker_count: 2, http: { keepalive_timeout: 120 } }`
 - `remote_sup`: Address to a remote Supervisor's Control Gateway [default: 127.0.0.1:9632]
 - `remote_sup_http`: Address for remote supervisor http port. Used to pull existing configuration data. If this is invalid, config will be applied on every Chef run.
+- `gateway_auth_token`: Auth token for accessing the remote supervisor's http port.
 - `user`: Name of user key to use for encryption. Passes `--user` to `hab config apply`
 
 #### Notes

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,12 +33,20 @@ suites:
     run_list: test::service
     excludes:
       - windows-2016
+  - name: service-auth
+    run_list: test::service_auth
+    excludes:
+      - windows-2016
   - name: sup
     run_list: test::sup
     excludes:
       - windows-2016
   - name: config
     run_list: test::config
+    excludes:
+      - windows-2016
+  - name: config-auth
+    run_list: test::config_auth
     excludes:
       - windows-2016
   - name: user-toml
@@ -51,6 +59,13 @@ suites:
       - windows-2016
   - name: config-chef-13
     run_list: test::config
+    excludes:
+      - windows-2016
+    provisioner:
+      product_name: chef
+      product_version: 13.6.4
+  - name: config-chef-13-auth
+    run_list: test::config_auth
     excludes:
       - windows-2016
     provisioner:
@@ -70,6 +85,10 @@ suites:
       - windows-2016
   - name: win-config
     run_list: test::win_config
+    includes:
+      - windows-2016
+  - name: win-config-auth
+    run_list: test::win_config_auth
     includes:
       - windows-2016
   - name: win-user-toml

--- a/libraries/provider_hab_package.rb
+++ b/libraries/provider_hab_package.rb
@@ -114,8 +114,6 @@ class Chef
             'target=x86_64-windows'
           elsif platform_family?('rhel') && node['platform_version'].to_f < 6.0
             'target=x86_64-linux-kernel2'
-          elsif platform_family?('centos') && node['platform_version'].to_f < 6.0
-            'target=x86_64-linux-kernel2'
           elsif platform_family?('suse') && node['platform_version'].to_f < 6.0
             'target=x86_64-linux-kernel2'
           else

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -35,6 +35,7 @@ class Chef
       property :hab_channel, String
       property :auto_update, [true, false], default: false
       property :auth_token, String
+      property :gateway_auth_token, String
       property :limit_no_files, String
       property :license, String, equal_to: ['accept']
       property :health_check_interval, coerce: proc { |h| h.is_a?(String) ? h : h.to_s }

--- a/libraries/resource_hab_sup_systemd.rb
+++ b/libraries/resource_hab_sup_systemd.rb
@@ -28,13 +28,16 @@ class Chef
       action :run do
         super()
 
+        service_environment = []
+        service_environment.push("HAB_AUTH_TOKEN=#{new_resource.auth_token}") if new_resource.auth_token
+        service_environment.push("HAB_SUP_GATEWAY_AUTH_TOKEN=#{new_resource.gateway_auth_token}") if new_resource.gateway_auth_token
         systemd_unit 'hab-sup.service' do
           content(Unit: {
                     Description: 'The Habitat Supervisor',
                   },
                   Service: {
                     LimitNOFILE: (new_resource.limit_no_files if new_resource.limit_no_files),
-                    Environment: ("HAB_AUTH_TOKEN=#{new_resource.auth_token}" if new_resource.auth_token),
+                    Environment: service_environment,
                     ExecStart: "/bin/hab sup run #{exec_start_options}",
                     Restart: 'on-failure',
                   }.compact,

--- a/libraries/resource_hab_sup_sysvinit.rb
+++ b/libraries/resource_hab_sup_sysvinit.rb
@@ -37,7 +37,8 @@ class Chef
           mode '0755'
           variables(name: 'hab-sup',
                     exec_start_options: exec_start_options,
-                    auth_token: new_resource.auth_token)
+                    auth_token: new_resource.auth_token,
+                    gateway_auth_token: new_resource.gateway_auth_token)
           action :create
         end
 

--- a/libraries/resource_hab_sup_upstart.rb
+++ b/libraries/resource_hab_sup_upstart.rb
@@ -36,7 +36,8 @@ class Chef
           group 'root'
           mode '0644'
           variables(exec_start_options: exec_start_options,
-                    auth_token: new_resource.auth_token)
+                    auth_token: new_resource.auth_token,
+                    gateway_auth_token: new_resource.gateway_auth_token)
           action :create
         end
 

--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -37,6 +37,12 @@ class Chef
           action auth_action
         end
 
+        gateway_auth_action = new_resource.gateway_auth_token ? :create : :delete
+        windows_env 'HAB_SUP_GATEWAY_AUTH_TOKEN' do
+          value new_resource.gateway_auth_token if new_resource.gateway_auth_token
+          action gateway_auth_action
+        end
+
         hab_package 'core/windows-service' do
           bldr_url new_resource.bldr_url if new_resource.bldr_url
           version hab_windows_service_version
@@ -55,6 +61,7 @@ class Chef
 
         service 'Habitat' do
           subscribes :restart, 'windows_env[HAB_AUTH_TOKEN]'
+          subscribes :restart, 'windows_env[HAB_SUP_GATEWAY_AUTH_TOKEN]'
           subscribes :restart, 'template[C:/hab/svc/windows-service/HabService.exe.config]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'

--- a/spec/unit/service_auth_spec.rb
+++ b/spec/unit/service_auth_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'test::service_auth' do
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new(
+      platform: 'ubuntu',
+      version: '16.04'
+    ).converge(described_recipe)
+  end
+
+  before(:each) do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:systemd])
+  end
+
+  context 'when compiling the service recipe for chefspec' do
+    it 'loads service' do
+      expect(chef_run).to load_hab_service('core/nginx')
+    end
+
+    it 'unloads service' do
+      expect(chef_run).to unload_hab_service('core/nginx unload')
+    end
+  end
+end

--- a/spec/unit/sup_spec.rb
+++ b/spec/unit/sup_spec.rb
@@ -24,6 +24,15 @@ describe 'test::sup' do
           )
       end
 
+      it 'runs hab sup with a gateway auth token' do
+        expect(chef_run).to run_hab_sup('test-gateway-auth-token')
+          .with(
+            listen_http: '0.0.0.0:10001',
+            listen_gossip: '0.0.0.0:10000',
+            gateway_auth_token: 'secret'
+          )
+      end
+
       it 'run hab sup with a single peer' do
         expect(chef_run).to run_hab_sup('single_peer').with(
           peer: ['127.0.0.2']
@@ -79,6 +88,7 @@ describe 'test::sup' do
               Description: 'The Habitat Supervisor',
             },
             Service: {
+              Environment: [],
               ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
               Restart: 'on-failure',
             },
@@ -128,6 +138,7 @@ describe 'test::sup' do
           variables: {
             exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
             auth_token: nil,
+            gateway_auth_token: nil,
           }
         )
       end
@@ -173,6 +184,7 @@ describe 'test::sup' do
             name: 'hab-sup',
             exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
             auth_token: nil,
+            gateway_auth_token: nil,
           }
         )
       end

--- a/templates/sysvinit/hab-sup-debian.erb
+++ b/templates/sysvinit/hab-sup-debian.erb
@@ -56,6 +56,11 @@ case "$1" in
     export HAB_AUTH_TOKEN=<%= @auth_token %>
     <% end %>
 
+    <% if @gateway_auth_token %>
+    log_daemon_msg "Setting HAB_SUP_GATEWAY_AUTH_TOKEN for $DESC" "$NAME"
+    export HAB_SUP_GATEWAY_AUTH_TOKEN=<%= @gateway_auth_token %>
+    <% end %>
+
     log_daemon_msg "Starting $DESC" "$NAME"
     if running; then
       log_progress_msg "already running ($(pid))"

--- a/templates/upstart/hab-sup.conf.erb
+++ b/templates/upstart/hab-sup.conf.erb
@@ -9,6 +9,9 @@ respawn limit 5 30
 <% if @auth_token %>
 env HAB_AUTH_TOKEN=<%= @auth_token %>
 <% end %>
+<% if @gateway_auth_token %>
+env HAB_SUP_GATEWAY_AUTH_TOKEN=<%= @gateway_auth_token %>
+<% end %>
 
 script
     exec /bin/hab sup run <%= @exec_start_options %>

--- a/test/fixtures/cookbooks/test/recipes/config_auth.rb
+++ b/test/fixtures/cookbooks/test/recipes/config_auth.rb
@@ -1,0 +1,50 @@
+apt_update
+
+hab_sup 'default' do
+  gateway_auth_token 'secret'
+  license 'accept'
+end
+
+ruby_block 'wait-for-sup-default-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
+hab_package 'core/nginx'
+hab_service 'core/nginx' do
+  gateway_auth_token 'secret'
+end
+
+# we need to sleep to let the nginx service have enough time to
+# startup properly before we can configure it.
+# This is here due to https://github.com/habitat-sh/habitat/issues/3155 and
+# can be removed if that issue is fixed.
+ruby_block 'wait-for-nginx-startup' do
+  block do
+    sleep 3
+  end
+  action :nothing
+  subscribes :run, 'hab_service[core/nginx]', :immediately
+end
+
+hab_config 'nginx.default' do
+  config(
+    worker_processes: 2,
+    http: {
+      keepalive_timeout: 120,
+    }
+  )
+  gateway_auth_token 'secret'
+end
+
+# Allow some time for the config to apply before running tests
+ruby_block 'wait-for-nginx-config' do
+  block do
+    sleep 3
+  end
+  action :nothing
+  subscribes :run, 'hab_config[nginx.default]', :immediately
+end

--- a/test/fixtures/cookbooks/test/recipes/service_auth.rb
+++ b/test/fixtures/cookbooks/test/recipes/service_auth.rb
@@ -1,0 +1,34 @@
+hab_sup 'default' do
+  hab_channel 'stable'
+  license 'accept'
+  gateway_auth_token 'secret'
+end
+
+ruby_block 'wait-for-sup-default-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
+hab_package 'core/nginx'
+hab_service 'core/nginx' do
+  gateway_auth_token 'secret'
+end
+
+# we need to sleep to let the nginx service have enough time to
+# startup properly before we can unload it.
+ruby_block 'wait-for-nginx-startup' do
+  block do
+    sleep 3
+  end
+  action :nothing
+  subscribes :run, 'hab_service[core/nginx]', :immediately
+end
+
+hab_service 'core/nginx unload' do
+  service_name 'core/nginx'
+  gateway_auth_token 'secret'
+  action :unload
+end

--- a/test/fixtures/cookbooks/test/recipes/sup.rb
+++ b/test/fixtures/cookbooks/test/recipes/sup.rb
@@ -51,12 +51,47 @@ ruby_block 'wait-for-sup-test-auth-token-startup' do
   retry_delay 1
 end
 
+hab_sup 'test-gateway-auth-token' do
+  license 'accept'
+  gateway_auth_token 'secret'
+  listen_http '0.0.0.0:10001'
+  listen_gossip '0.0.0.0:10000'
+  notifies :stop, 'hab_sup[test-auth-token]', :before
+  notifies :delete, 'directory[/hab/sup]', :before
+end
+
+ruby_block 'wait-for-sup-test-gateway-auth-token-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
+hab_sup 'test-gateway-auth-and-auth-token' do
+  license 'accept'
+  auth_token 'test'
+  gateway_auth_token 'secret'
+  listen_http '0.0.0.0:10001'
+  listen_gossip '0.0.0.0:10000'
+  notifies :stop, 'hab_sup[test-gateway-auth-token]', :before
+  notifies :delete, 'directory[/hab/sup]', :before
+end
+
+ruby_block 'wait-for-sup-test-gateway-auth-and-auth-token-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
 hab_sup 'single_peer' do
   license 'accept'
   listen_http '0.0.0.0:8999'
   listen_gossip '0.0.0.0:8998'
   peer '127.0.0.2'
-  notifies :stop, 'hab_sup[test-auth-token]', :before
+  notifies :stop, 'hab_sup[test-gateway-auth-and-auth-token]', :before
   notifies :delete, 'directory[/hab/sup]', :before
 end
 

--- a/test/fixtures/cookbooks/test/recipes/win_config_auth.rb
+++ b/test/fixtures/cookbooks/test/recipes/win_config_auth.rb
@@ -1,0 +1,28 @@
+hab_sup 'default' do
+  gateway_auth_token 'secret'
+  license 'accept'
+end
+
+ruby_block 'wait-for-sup-default-startup' do
+  block do
+    raise unless system('hab sup status')
+  end
+  retries 30
+  retry_delay 1
+end
+
+hab_package 'skylerto/splunkforwarder'
+hab_service 'skylerto/splunkforwarder' do
+  gateway_auth_token 'secret'
+end
+
+hab_config 'splunkforwarder.default' do
+  config(
+    directories: {
+      path: [
+        'C:/hab/pkgs/.../*.log',
+      ],
+    }
+  )
+  gateway_auth_token 'secret'
+end

--- a/test/integration/config-auth/default_spec.rb
+++ b/test/integration/config-auth/default_spec.rb
@@ -1,0 +1,24 @@
+describe user('hab') do
+  it { should exist }
+end
+
+describe file('/bin/hab') do
+  it { should exist }
+  it { should be_symlink }
+end
+
+# This needs to be updated each time Habitat is released so we ensure we're getting the version
+# required by this cookbook.
+describe command('hab -V') do
+  its('stdout') { should match(%r{^hab 0.88.0/}) }
+  its('exit_status') { should eq 0 }
+end
+
+describe json('/hab/sup/default/data/census.dat') do
+  scpath = ['census_groups', 'nginx.default', 'service_config']
+  # Incarnation is just the current timestamp, so we can't compare to an exact
+  # value. Instead just make sure it looks right.
+  its(scpath + ['incarnation']) { should be > 1_500_000_000 }
+  its(scpath + %w(value worker_processes)) { should eq 2 }
+  its(scpath + %w(value http keepalive_timeout)) { should eq 120 }
+end

--- a/test/integration/service-auth/default_spec.rb
+++ b/test/integration/service-auth/default_spec.rb
@@ -1,0 +1,3 @@
+describe directory('/hab/pkgs/core/nginx') do
+  it { should exist }
+end

--- a/test/integration/sup/default_spec.rb
+++ b/test/integration/sup/default_spec.rb
@@ -36,14 +36,17 @@ case svc_manager
 when 'systemd'
   describe file('/etc/systemd/system/hab-sup.service') do
     its('content') { should_not match('Environment = HAB_AUTH_TOKEN=test') }
+    its('content') { should_not match('Environment = HAB_SUP_GATEWAY_AUTH_TOKEN=secret') }
     its('content') { should_not match('LimitNOFILE = 65536') }
   end
 when 'upstart'
   describe file('/etc/init/hab-sup.conf') do
     its('content') { should_not match('env HAB_AUTH_TOKEN=test') }
+    its('content') { should_not match('env HAB_SUP_GATEWAY_AUTH_TOKEN=secret') }
   end
 when 'sysv'
   describe file('/etc/init.d/hab-sup') do
     its('content') { should_not match('export HAB_AUTH_TOKEN=test') }
+    its('content') { should_not match('export HAB_SUP_GATEWAY_AUTH_TOKEN=secret') }
   end
 end

--- a/test/integration/win-config-auth/default_spec.rb
+++ b/test/integration/win-config-auth/default_spec.rb
@@ -1,0 +1,21 @@
+describe file('C:\habitat\hab.exe') do
+  it { should exist }
+end
+
+# This needs to be updated each time Habitat is released so we ensure we're getting the version
+# required by this cookbook.
+# TODO: Inspec session seems to not have the updated windows system path when run with 'kitchen test'
+# Works fine if you run a converge and then a verify as two seperate commands
+# For now, hitting hab.exe directly to avoid test failure
+describe command('C:\habitat\hab.exe -V') do
+  its('stdout') { should match(%r{^hab 0.67.0/}) }
+  its('exit_status') { should eq 0 }
+end
+
+describe json('C:\hab\sup\default\data\census.dat') do
+  scpath = ['census_groups', 'splunkforwarder.default', 'service_config']
+  # Incarnation is just the current timestamp, so we can't compare to an exact
+  # value. Instead just make sure it looks right.
+  its(scpath + ['incarnation']) { should be > 1_500_000_000 }
+  its(scpath + %w(value directories path)) { should eq ['C:/hab/pkgs/.../*.log'] }
+end


### PR DESCRIPTION
### Description

Adds options to the `hab_sup`, `hab_service` and `hab_config` resources to enable authentication on the HTTP gateway.

Fixed some Cookstyle errors along the way.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
