### PR TITLE
Service Properties, Reload/Restart Fixes, Idempotence Improvements

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -21,23 +21,48 @@ property :loaded, [true, false], default: false, desired_state: true
 property :running, [true, false], default: false, desired_state: true
 
 # hab svc options which get included based on the action of the resource
-property :strategy, String
-property :topology, String
-property :bldr_url, String
-property :channel, [Symbol, String]
-property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }
+property :strategy, [Symbol, String], equal_to: [:none, 'none', :'at-once', 'at-once', :rolling, 'rolling'], default: :none
+property :topology, [Symbol, String], equal_to: [:standalone, 'standalone', :leader, 'leader'], default: :standalone
+property :bldr_url, String, default: 'https://bldr.habitat.sh'
+property :channel, [Symbol, String], default: :stable
+property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }, default: []
 property :binding_mode, [Symbol, String], equal_to: [:strict, 'strict', :relaxed, 'relaxed'], default: :strict
-property :service_group, String
+property :service_group, String, default: 'default'
+property :shutdown_timeout, Integer, default: 8
+property :health_check_interval, Integer, default: 30
 property :remote_sup, String, default: '127.0.0.1:9632', desired_state: false
 # Http port needed for querying/comparing current config value
 property :remote_sup_http, String, default: '127.0.0.1:9631', desired_state: false
 
 load_current_value do
-  running service_up?(service_name)
-  loaded service_loaded?(service_name)
+  service_details = get_service_details(service_name)
+
+  running service_up?(service_details)
+  loaded service_loaded?(service_details)
+
+  if loaded
+    strategy get_update_strategy(service_details)
+    topology get_topology(service_details)
+    bldr_url get_builder_url(service_details)
+    channel get_channel(service_details)
+    bind get_binds(service_details)
+    binding_mode get_binding_mode(service_details)
+    service_group get_service_group(service_details)
+    shutdown_timeout get_shutdown_timeout(service_details)
+    health_check_interval get_health_check_interval(service_details)
+  end
 
   Chef::Log.debug("service #{service_name} running state: #{running}")
   Chef::Log.debug("service #{service_name} loaded state: #{loaded}")
+  Chef::Log.debug("service #{service_name} strategy: #{strategy}")
+  Chef::Log.debug("service #{service_name} topology: #{topology}")
+  Chef::Log.debug("service #{service_name} builder url: #{bldr_url}")
+  Chef::Log.debug("service #{service_name} channel: #{channel}")
+  Chef::Log.debug("service #{service_name} binds: #{bind}")
+  Chef::Log.debug("service #{service_name} binding mode: #{binding_mode}")
+  Chef::Log.debug("service #{service_name} service group: #{service_group}")
+  Chef::Log.debug("service #{service_name} shutdown timeout: #{shutdown_timeout}")
+  Chef::Log.debug("service #{service_name} health check interval: #{health_check_interval}")
 end
 
 # This method is defined here otherwise it isn't usable in the
@@ -80,30 +105,124 @@ def get_service_details(svc_name)
   end
 end
 
-def service_up?(svc_name)
-  sup_for_service_name = get_service_details(svc_name)
-
+def service_up?(service_details)
   begin
-    sup_for_service_name['process']['state'] == 'up'
+    service_details['process']['state'] == 'up'
   rescue
-    Chef::Log.debug("#{service_name} not found the Habitat supervisor")
+    Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
     false
   end
 end
 
-def service_loaded?(svc_name)
-  sup_for_service_name = get_service_details(svc_name)
-
-  if sup_for_service_name
+def service_loaded?(service_details)
+  if service_details
     true
   else
     false
   end
 end
 
-# TODO: Load should detect if options such as bldr_url, channel, binds, etc have changed and reload if they have
+def get_update_strategy(service_details)
+  begin
+    service_details['update_strategy']
+  rescue
+    Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
+    'none'
+  end
+end
+
+def get_topology(service_details)
+  begin
+    service_details['topology']
+  rescue
+    Chef::Log.debug("Topology for #{service_name} not found on Supervisor API")
+    'standalone'
+  end
+end
+
+def get_builder_url(service_details)
+  begin
+    service_details['bldr_url']
+  rescue
+    Chef::Log.debug("Builder URL for #{service_name} not found on Supervisor API")
+    'https://bldr.habitat.sh'
+  end
+end
+
+def get_channel(service_details)
+  begin
+    service_details['channel']
+  rescue
+    Chef::Log.debug("Channel for #{service_name} not found on Supervisor API")
+    'stable'
+  end
+end
+
+def get_binds(service_details)
+  begin
+    service_details['binds']
+  rescue
+    Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
+    []
+  end
+end
+
+def get_binding_mode(service_details)
+  begin
+    service_details['binding_mode']
+  rescue
+    Chef::Log.debug("Binding mode for #{service_name} not found on Supervisor API")
+    'strict'
+  end
+end
+
+def get_service_group(service_details)
+  begin
+    service_details['service_group'].split('.').last
+  rescue
+    Chef::Log.debug("Service Group for #{service_name} not found on Supervisor API")
+    'default'
+  end
+end
+
+def get_shutdown_timeout(service_details)
+  begin
+    service_details['pkg']['shutdown_timeout']
+  rescue
+    Chef::Log.debug("Shutdown Timeout for #{service_name} not found on Supervisor API")
+    8
+  end
+end
+
+def get_health_check_interval(service_details)
+  begin
+    service_details['health_check_interval']['secs']
+  rescue
+    Chef::Log.debug("Health Check Interval for #{service_name} not found on Supervisor API")
+    30
+  end
+end
+
 action :load do
-  execute "hab svc load #{new_resource.service_name} #{svc_options.join(' ')}" unless current_resource.loaded
+  reload = false
+
+  converge_if_changed :strategy do reload = true end
+  converge_if_changed :topology do reload = true end
+  converge_if_changed :bldr_url do reload = true end
+  converge_if_changed :channel do reload = true end
+  converge_if_changed :bind do reload = true end
+  converge_if_changed :binding_mode do reload = true end
+  converge_if_changed :service_group do reload = true end
+  converge_if_changed :shutdown_timeout do reload = true end
+  converge_if_changed :health_check_interval do reload = true end
+
+  options = svc_options
+  if reload
+    Chef::Log.debug("Reloading #{current_resource.service_name} using --force due to parameter change")
+    options << "--force"
+  end
+
+  execute "hab svc load #{new_resource.service_name} #{options.join(' ')}" unless current_resource.loaded && !reload
 end
 
 action :unload do
@@ -111,31 +230,50 @@ action :unload do
 end
 
 action :start do
-  # FIXME: Should we do this, which matches the expected Hab workflow, or call action_load?
   unless current_resource.loaded
-    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded in the Habitat supervisor")
-    raise
+    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded on the Habitat supervisor")
+    raise "No service named #{new_resource.service_name} is loaded on the Habitat supervisor"
   end
+
   execute "hab svc start #{new_resource.service_name} #{svc_options.join(' ')}" unless current_resource.running
 end
 
 action :stop do
   unless current_resource.loaded
-    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded in the Habitat supervisor")
-    raise
+    Chef::Log.fatal("No service named #{new_resource.service_name} is loaded on the Habitat supervisor")
+    raise "No service named #{new_resource.service_name} is loaded on the Habitat supervisor"
   end
+
   execute "hab svc stop #{new_resource.service_name} #{svc_options.join(' ')}" if current_resource.running
 end
 
 action :restart do
-  action_stop
-  sleep 1
-  action_start
+  action_unload
+  ruby_block do
+    block do
+      service_details = get_service_details(new_resource.service_name)
+      raise "#{new_resource.service_name} still started" if service_up?(service_details)
+    end
+    retries get_shutdown_timeout(new_resource.service_name) + 1
+    retry_delay 1
+    action :nothing
+    subscribes :run, 'action_unload[stop as part of reload]', :immediately
+  end
+  action_load
 end
 
 action :reload do
   action_unload
-  sleep 1
+  ruby_block do
+    block do
+      service_details = get_service_details(new_resource.service_name)
+      raise "#{new_resource.service_name} still loaded" if service_loaded?(service_details)
+    end
+    retries get_shutdown_timeout(new_resource.service_name) + 1
+    retry_delay 1
+    action :nothing
+    subscribes :run, 'action_unload[unload as part of reload]', :immediately
+  end
   action_load
 end
 
@@ -153,6 +291,10 @@ action_class do
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
       opts << "--topology #{new_resource.topology}" if new_resource.topology
+      opts << "--health-check-interval #{new_resource.health_check_interval}" if new_resource.health_check_interval
+      opts << "--shutdown-timeout #{new_resource.shutdown_timeout}" if new_resource.shutdown_timeout
+    when :unload, :stop
+      opts << "--shutdown-timeout #{new_resource.shutdown_timeout}" if new_resource.shutdown_timeout
     end
 
     opts << "--remote-sup #{new_resource.remote_sup}" if new_resource.remote_sup

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -99,9 +99,8 @@ def get_service_details(svc_name)
   end
 
   origin, name, _version, _release = svc_name.split('/')
-  sanitized_name = [origin, name].join('/')
   svcs.find do |s|
-    [s['pkg']['origin'], s['pkg']['name']].join('/') == sanitized_name
+    s['pkg']['origin'] == origin && s['pkg']['name'] == name
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -21,12 +21,12 @@ property :loaded, [true, false], default: false, desired_state: true
 property :running, [true, false], default: false, desired_state: true
 
 # hab svc options which get included based on the action of the resource
-property :strategy, [Symbol, String], equal_to: [:none, 'none', :'at-once', 'at-once', :rolling, 'rolling'], default: :none
-property :topology, [Symbol, String], equal_to: [:standalone, 'standalone', :leader, 'leader'], default: :standalone
+property :strategy, [Symbol, String], equal_to: [:none, 'none', :'at-once', 'at-once', :rolling, 'rolling'], default: :none, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
+property :topology, [Symbol, String], equal_to: [:standalone, 'standalone', :leader, 'leader'], default: :standalone, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 property :bldr_url, String, default: 'https://bldr.habitat.sh'
-property :channel, [Symbol, String], default: :stable
+property :channel, [Symbol, String], default: :stable, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }, default: []
-property :binding_mode, [Symbol, String], equal_to: [:strict, 'strict', :relaxed, 'relaxed'], default: :strict
+property :binding_mode, [Symbol, String], equal_to: [:strict, 'strict', :relaxed, 'relaxed'], default: :strict, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 property :service_group, String, default: 'default'
 property :shutdown_timeout, Integer, default: 8
 property :health_check_interval, Integer, default: 30
@@ -124,7 +124,7 @@ end
 
 def get_update_strategy(service_details)
   begin
-    service_details['update_strategy']
+    service_details['update_strategy'].to_sym
   rescue
     Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
     'none'
@@ -133,7 +133,7 @@ end
 
 def get_topology(service_details)
   begin
-    service_details['topology']
+    service_details['topology'].to_sym
   rescue
     Chef::Log.debug("Topology for #{service_name} not found on Supervisor API")
     'standalone'
@@ -151,7 +151,7 @@ end
 
 def get_channel(service_details)
   begin
-    service_details['channel']
+    service_details['channel'].to_sym
   rescue
     Chef::Log.debug("Channel for #{service_name} not found on Supervisor API")
     'stable'
@@ -169,7 +169,7 @@ end
 
 def get_binding_mode(service_details)
   begin
-    service_details['binding_mode']
+    service_details['binding_mode'].to_sym
   rescue
     Chef::Log.debug("Binding mode for #{service_name} not found on Supervisor API")
     'strict'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -41,6 +41,7 @@ load_current_value do
   loaded service_loaded?(service_details)
 
   if loaded
+    service_name get_spec_identifier(service_details)
     strategy get_update_strategy(service_details)
     topology get_topology(service_details)
     bldr_url get_builder_url(service_details)
@@ -52,6 +53,7 @@ load_current_value do
     health_check_interval get_health_check_interval(service_details)
   end
 
+  Chef::Log.debug("service #{service_name} service name: #{service_name}")
   Chef::Log.debug("service #{service_name} running state: #{running}")
   Chef::Log.debug("service #{service_name} loaded state: #{loaded}")
   Chef::Log.debug("service #{service_name} strategy: #{strategy}")
@@ -118,6 +120,15 @@ def service_loaded?(service_details)
     true
   else
     false
+  end
+end
+
+def get_spec_identifier(service_details)
+  begin
+    service_details['spec_ident']['spec_identifier']
+  rescue
+    Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
+    nil
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -204,25 +204,25 @@ def get_health_check_interval(service_details)
 end
 
 action :load do
-  reload = false
-
-  converge_if_changed :strategy do reload = true end
-  converge_if_changed :topology do reload = true end
-  converge_if_changed :bldr_url do reload = true end
-  converge_if_changed :channel do reload = true end
-  converge_if_changed :bind do reload = true end
-  converge_if_changed :binding_mode do reload = true end
-  converge_if_changed :service_group do reload = true end
-  converge_if_changed :shutdown_timeout do reload = true end
-  converge_if_changed :health_check_interval do reload = true end
+  modified = false
+  converge_if_changed :service_name do modified = true end
+  converge_if_changed :strategy do modified = true end
+  converge_if_changed :topology do modified = true end
+  converge_if_changed :bldr_url do modified = true end
+  converge_if_changed :channel do modified = true end
+  converge_if_changed :bind do modified = true end
+  converge_if_changed :binding_mode do modified = true end
+  converge_if_changed :service_group do modified = true end
+  converge_if_changed :shutdown_timeout do modified = true end
+  converge_if_changed :health_check_interval do modified = true end
 
   options = svc_options
-  if reload
+  if current_resource.loaded && modified
     Chef::Log.debug("Reloading #{current_resource.service_name} using --force due to parameter change")
     options << "--force"
   end
 
-  execute "hab svc load #{new_resource.service_name} #{options.join(' ')}" unless current_resource.loaded && !reload
+  execute "hab svc load #{new_resource.service_name} #{options.join(' ')}" unless current_resource.loaded && !modified
 end
 
 action :unload do

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -107,12 +107,10 @@ def get_service_details(svc_name)
 end
 
 def service_up?(service_details)
-  begin
-    service_details['process']['state'] == 'up'
-  rescue
-    Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
-    false
-  end
+  service_details['process']['state'] == 'up'
+rescue
+  Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
+  false
 end
 
 def service_loaded?(service_details)
@@ -124,112 +122,112 @@ def service_loaded?(service_details)
 end
 
 def get_spec_identifier(service_details)
-  begin
-    service_details['spec_ident']['spec_identifier']
-  rescue
-    Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
-    nil
-  end
+  service_details['spec_ident']['spec_identifier']
+rescue
+  Chef::Log.debug("#{service_name} not found on the Habitat supervisor")
+  nil
 end
 
 def get_update_strategy(service_details)
-  begin
-    service_details['update_strategy'].to_sym
-  rescue
-    Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
-    'none'
-  end
+  service_details['update_strategy'].to_sym
+rescue
+  Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
+  'none'
 end
 
 def get_topology(service_details)
-  begin
-    service_details['topology'].to_sym
-  rescue
-    Chef::Log.debug("Topology for #{service_name} not found on Supervisor API")
-    'standalone'
-  end
+  service_details['topology'].to_sym
+rescue
+  Chef::Log.debug("Topology for #{service_name} not found on Supervisor API")
+  'standalone'
 end
 
 def get_builder_url(service_details)
-  begin
-    service_details['bldr_url']
-  rescue
-    Chef::Log.debug("Builder URL for #{service_name} not found on Supervisor API")
-    'https://bldr.habitat.sh'
-  end
+  service_details['bldr_url']
+rescue
+  Chef::Log.debug("Builder URL for #{service_name} not found on Supervisor API")
+  'https://bldr.habitat.sh'
 end
 
 def get_channel(service_details)
-  begin
-    service_details['channel'].to_sym
-  rescue
-    Chef::Log.debug("Channel for #{service_name} not found on Supervisor API")
-    'stable'
-  end
+  service_details['channel'].to_sym
+rescue
+  Chef::Log.debug("Channel for #{service_name} not found on Supervisor API")
+  'stable'
 end
 
 def get_binds(service_details)
-  begin
-    service_details['binds']
-  rescue
-    Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
-    []
-  end
+  service_details['binds']
+rescue
+  Chef::Log.debug("Update Strategy for #{service_name} not found on Supervisor API")
+  []
 end
 
 def get_binding_mode(service_details)
-  begin
-    service_details['binding_mode'].to_sym
-  rescue
-    Chef::Log.debug("Binding mode for #{service_name} not found on Supervisor API")
-    'strict'
-  end
+  service_details['binding_mode'].to_sym
+rescue
+  Chef::Log.debug("Binding mode for #{service_name} not found on Supervisor API")
+  'strict'
 end
 
 def get_service_group(service_details)
-  begin
-    service_details['service_group'].split('.').last
-  rescue
-    Chef::Log.debug("Service Group for #{service_name} not found on Supervisor API")
-    'default'
-  end
+  service_details['service_group'].split('.').last
+rescue
+  Chef::Log.debug("Service Group for #{service_name} not found on Supervisor API")
+  'default'
 end
 
 def get_shutdown_timeout(service_details)
-  begin
-    service_details['pkg']['shutdown_timeout']
-  rescue
-    Chef::Log.debug("Shutdown Timeout for #{service_name} not found on Supervisor API")
-    8
-  end
+  service_details['pkg']['shutdown_timeout']
+rescue
+  Chef::Log.debug("Shutdown Timeout for #{service_name} not found on Supervisor API")
+  8
 end
 
 def get_health_check_interval(service_details)
-  begin
-    service_details['health_check_interval']['secs']
-  rescue
-    Chef::Log.debug("Health Check Interval for #{service_name} not found on Supervisor API")
-    30
-  end
+  service_details['health_check_interval']['secs']
+rescue
+  Chef::Log.debug("Health Check Interval for #{service_name} not found on Supervisor API")
+  30
 end
 
 action :load do
   modified = false
-  converge_if_changed :service_name do modified = true end
-  converge_if_changed :strategy do modified = true end
-  converge_if_changed :topology do modified = true end
-  converge_if_changed :bldr_url do modified = true end
-  converge_if_changed :channel do modified = true end
-  converge_if_changed :bind do modified = true end
-  converge_if_changed :binding_mode do modified = true end
-  converge_if_changed :service_group do modified = true end
-  converge_if_changed :shutdown_timeout do modified = true end
-  converge_if_changed :health_check_interval do modified = true end
+  converge_if_changed :service_name do
+    modified = true
+  end
+  converge_if_changed :strategy do
+    modified = true
+  end
+  converge_if_changed :topology do
+    modified = true
+  end
+  converge_if_changed :bldr_url do
+    modified = true
+  end
+  converge_if_changed :channel do
+    modified = true
+  end
+  converge_if_changed :bind do
+    modified = true
+  end
+  converge_if_changed :binding_mode do
+    modified = true
+  end
+  converge_if_changed :service_group do
+    modified = true
+  end
+  converge_if_changed :shutdown_timeout do
+    modified = true
+  end
+  converge_if_changed :health_check_interval do
+    modified = true
+  end
 
   options = svc_options
   if current_resource.loaded && modified
     Chef::Log.debug("Reloading #{current_resource.service_name} using --force due to parameter change")
-    options << "--force"
+    options << '--force'
   end
 
   execute "hab svc load #{new_resource.service_name} #{options.join(' ')}" unless current_resource.loaded && !modified

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -25,18 +25,35 @@ describe 'test::service' do
       expect(chef_run).to unload_hab_service('core/nginx unload')
     end
 
+    it 'loads a service with version' do
+      expect(chef_run).to load_hab_service('core/vault version change').with(
+        service_name: 'core/vault/1.1.5'
+      )
+    end
+
+    it 'loads a service with version and release' do
+      expect(chef_run).to load_hab_service('core/grafana full identifier').with(
+        service_name: 'core/grafana/6.4.3/20191105024430'
+      )
+    end
+
     it 'loads a service with options' do
-      expect(chef_run).to load_hab_service('core/redis').with(
-        strategy: 'rolling',
-        topology: 'standalone',
-        channel: :stable
+      expect(chef_run).to load_hab_service('core/grafana property change from custom values').with(
+        service_group: 'test',
+        bldr_url: 'https://bldr-test.habitat.sh',
+        channel: :'bldr-1321420393699319808',
+        topology: :standalone,
+        strategy: :'at-once',
+        binding_mode: :relaxed,
+        shutdown_timeout: 10,
+        health_check_interval: 32
       )
     end
 
     it 'loads a service with a single bind' do
-      expect(chef_run).to load_hab_service('core/ruby-rails-sample').with(
+      expect(chef_run).to load_hab_service('core/grafana binding').with(
         bind: [
-          'database:postgresql.default',
+          'prom:prometheus.default',
         ]
       )
     end
@@ -48,6 +65,14 @@ describe 'test::service' do
           'redis:redis.default',
         ]
       )
+    end
+
+    it 'reloads a service' do
+      expect(chef_run).to reload_hab_service('core/consul reload')
+    end
+
+    it 'restarts a service' do
+      expect(chef_run).to restart_hab_service('core/consul restart')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -249,7 +249,7 @@ ruby_block 'wait-for-consul-up-for-30s' do
   subscribes :run, 'ruby_block[wait-for-consul-startup]', :immediately
 end
 
-hab_service 'core/consul restart' do
+hab_service 'core/consul reload' do
   service_name 'core/consul'
   action :reload
 end

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -32,8 +32,8 @@ end
 # redis: options, and then stop
 hab_package 'core/redis'
 hab_service 'core/redis' do
-  strategy 'rolling'
-  topology 'standalone'
+  strategy :rolling
+  topology :standalone
   channel :stable
 end
 

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -41,6 +41,11 @@ describe file('/hab/sup/default/specs/vault.spec') do
   its(:content) { should match(%r{ident = "core/vault/1.1.5"}) }
 end
 
+describe file('/hab/sup/default/specs/consul.spec') do
+  it { should exist }
+  its(:content) { should match(%r{ident = "core/consul"}) }
+end
+
 describe file('/hab/sup/default/specs/redis.spec') do
   it { should exist }
   its(:content) { should match(/desired_state = "down"/) }

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -16,7 +16,7 @@ end
 
 describe file('/hab/sup/default/specs/grafana.spec') do
   it { should exist }
-  its(:content) { should match(%r{ident = "core/grafana/4.6.3"}) }
+  its(:content) { should match(%r{ident = "core/grafana/6.4.3/20191105024430"}) }
   its(:content) { should match(/group = "test"/) }
   its(:content) { should match(%r{bldr_url = "https://bldr-test.habitat.sh"}) }
   its(:content) { should match(/channel = "bldr-1321420393699319808"/) }
@@ -28,12 +28,17 @@ describe file('/hab/sup/default/specs/grafana.spec') do
   its(:content) { should match(/\[health_check_interval\]\nsecs = 32/) }
 end
 
-describe directory('/hab/pkgs/core/grafana/4.6.3') do
+describe directory('/hab/pkgs/core/grafana/6.4.3/20191105024430') do
   it { should exist }
 end
 
-describe directory('/hab/pkgs/core/grafana/6.4.3/20191105024430') do
+describe directory('/hab/pkgs/core/vault/1.1.5') do
   it { should exist }
+end
+
+describe file('/hab/sup/default/specs/vault.spec') do
+  it { should exist }
+  its(:content) { should match(%r{ident = "core/vault/1.1.5"}) }
 end
 
 describe file('/hab/sup/default/specs/redis.spec') do

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -10,9 +10,22 @@ describe file('/hab/sup/default/specs/haproxy.spec') do
   it { should_not exist }
 end
 
+describe file('/hab/sup/default/specs/prometheus.spec') do
+  it { should exist }
+end
+
 describe file('/hab/sup/default/specs/grafana.spec') do
   it { should exist }
   its(:content) { should match(%r{ident = "core/grafana/4.6.3"}) }
+  its(:content) { should match(/group = "test"/) }
+  its(:content) { should match(%r{bldr_url = "https://bldr-test.habitat.sh"}) }
+  its(:content) { should match(/channel = "bldr-1321420393699319808"/) }
+  its(:content) { should match(/topology = "standalone"/) }
+  its(:content) { should match(/update_strategy = "at-once"/) }
+  its(:content) { should match(/binds = \["prom:prometheus.default"\]/) }
+  its(:content) { should match(/binding_mode = "relaxed"/) }
+  its(:content) { should match(/shutdown_timeout = 10/) }
+  its(:content) { should match(/\[health_check_interval\]\nsecs = 32/) }
 end
 
 describe directory('/hab/pkgs/core/grafana/4.6.3') do
@@ -32,10 +45,6 @@ end
 describe file('/hab/sup/default/specs/memcached.spec') do
   it { should exist }
   its(:content) { should match(/^desired_state = "up"$/) }
-end
-
-describe file('/hab/sup/default/specs/ruby-rails-sample.spec') do
-  it { should exist }
 end
 
 describe file('/hab/sup/default/specs/sensu.spec') do


### PR DESCRIPTION
### Description

This PR adds the following:
- Restricts input space of **strategy**, **topology**
- Adds support for **shutdown_timeout**, **health_check_interval**
- Sets defaults for **strategy**, **topology**, **bldr_url**, **channel**, **service_group**, **shutdown_timeout**, **health_check_interval**
- Adds Symbol as accepted type for **strategy**, **topology**. Coerces string to Symbol for these & channel to ensure correct state comparisons.
- Sets **service_name** in *load_current_value*, to allow the current state of the service to be picked up from the system, i.e. this will not throw an error:
  ```
  hab_service "core/vault"
  hab_service "core/vault/1.1.5"
  ```
  This also now compares the service_name provided by the user against the `spec_identifier`, re-loading it if the user has changed the level of granularity provided (i.e. added/removed version/release)
- Load using `--force` when properties have changed
- Wait for service to stop during `:reload`,`:restart` using **shutdown_timeout**
- Updating tests for the above

### Check List

- [ X     ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X     ] New functionality includes testing.
- [ N/A ] New functionality has been documented in the README if applicable
- [ X     ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
