### PR TITLE
Fix Habitat install on windows

### DIFF
--- a/libraries/habitat_shared.rb
+++ b/libraries/habitat_shared.rb
@@ -19,7 +19,7 @@ module Habitat
     HAB_VERSION = '0.88.0'.freeze
     LINUX_LAUNCHER_VERSION = '11055'.freeze
     WINDOWS_LAUNCHER_VERSION = '9106'.freeze
-    WINDOWS_SERVICE_VERSION = '0.3.1'.freeze
+    WINDOWS_SERVICE_VERSION = '0.5.0'.freeze
 
     def hab_version
       HAB_VERSION

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -48,8 +48,13 @@ action :install do
     # as a .sha265sum like for the linux .tar.gz
     download = "#{uri}/content/habitat/stable/windows/x86_64/#{package_name}.zip?bt_package=hab-x86_64-windows"
 
-    archive_file Chef::Config[:file_cache_path] do
-      path download
+    remote_file "#{Chef::Config[:file_cache_path]}/#{package_name}.zip" do
+      source download
+    end
+
+    archive_file "#{package_name}.zip" do
+      path "#{Chef::Config[:file_cache_path]}/#{package_name}.zip"
+      destination "#{Chef::Config[:file_cache_path]}/habitat"
       action :extract
     end
 
@@ -57,7 +62,7 @@ action :install do
 
     powershell_script 'installing from archive' do
       code <<-EOH
-      Move-Item -Path #{extracted_path} -Destination C:/habitat -Force
+      Move-Item -Path #{Chef::Config[:file_cache_path]}/habitat/#{package_name} -Destination C:/habitat -Force
       EOH
     end
 


### PR DESCRIPTION
### Description

This fixes the use of the `archive_file` resource but utilizing the `remote_file` resource to grab the Habitat package and then extract it

### Issues Resolved

#191 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
