### PR TITLE
Switch from toml gem to toml-rb gem for more robust parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
-  - CHEF_LICENSE=accept-no-persist chef gem install toml
+  - CHEF_LICENSE=accept-no-persist chef gem install toml-rb
   - CHEF_LICENSE=accept-no-persist chef --version
   - cookstyle --version
   - foodcritic --version

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ source 'https://rubygems.org'
 gem 'community_cookbook_releaser'
 
 # local development and testing requires this gem is installed.
-gem 'toml'
+gem 'toml-rb'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ issues_url 'https://github.com/chef-cookbooks/habitat/issues'
 
 chef_version '>= 12.20.3'
 
-gem 'toml'
+gem 'toml-rb'
 
 depends 'windows'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'toml'
+require 'toml-rb'
 require 'net/http'
 require 'json'
 
@@ -57,7 +57,7 @@ action :apply do
 
     tempfile = Tempfile.new(['hab_config', '.toml'])
     begin
-      tempfile.write(TOML::Generator.new(new_resource.config).body)
+      tempfile.write(TomlRB.dump(new_resource.config))
       tempfile.close
 
       hab('config', 'apply', opts, new_resource.service_group, incarnation, tempfile.path)

--- a/resources/user_toml.rb
+++ b/resources/user_toml.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'toml'
+require 'toml-rb'
 
 resource_name :hab_user_toml
 
@@ -34,7 +34,7 @@ action :create do
     mode '0600'
     owner root_owner
     group node['root_group']
-    content TOML::Generator.new(new_resource.config).body
+    content TomlRB.dump(new_resource.config)
     sensitive true
   end
 end

--- a/test/integration/user-toml/default_spec.rb
+++ b/test/integration/user-toml/default_spec.rb
@@ -16,7 +16,6 @@ end
 
 nginx_content = <<-EOF
 worker_processes = 2
-
 [http]
 keepalive_timeout = 120
 EOF


### PR DESCRIPTION
### Description

Switches toml parsing gems from `toml` to `toml-rb`.

### Issues Resolved

#190 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
