### PR TITLE
Fix windows package download URL

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -39,15 +39,13 @@ action :install do
 
   if platform_family?('windows')
     # Retrieve version information
-    uri = 'https://api.bintray.com'
-    result = Chef::HTTP::SimpleJSON.new(uri).get('/packages/habitat/stable/hab-x86_64-windows')
-    build_version = result['versions'].grep(/^#{hab_version}/).first
-    package_name = "hab-#{build_version}-x86_64-windows"
+    uri = 'https://packages.chef.io/files'
+    package_name = 'hab-latest-x86_64-windows'
     zipfile = "#{Chef::Config[:file_cache_path]}/#{package_name}.zip"
 
     # TODO: Figure out how to properly validate the shasum for windows. Doesn't seem it's published
     # as a .sha265sum like for the linux .tar.gz
-    download = "#{uri}/content/habitat/stable/windows/x86_64/#{package_name}.zip?bt_package=hab-x86_64-windows"
+    download = "#{uri}/stable/habitat/latest/hab-x86_64-windows.zip"
 
     remote_file zipfile do
       source download

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -103,15 +103,13 @@ end
 action :upgrade do
   if platform_family?('windows')
     # Retrieve version information
-    uri = 'https://api.bintray.com'
-    result = Chef::HTTP::SimpleJSON.new(uri).get('/packages/habitat/stable/hab-x86_64-windows')
-    build_version = result['versions'].grep(/^#{hab_version}/).first
-    package_name = "hab-#{build_version}-x86_64-windows"
+    uri = 'https://packages.chef.io/files'
+    package_name = 'hab-latest-x86_64-windows'
     zipfile = "#{Chef::Config[:file_cache_path]}/#{package_name}.zip"
 
     # TODO: Figure out how to properly validate the shasum for windows. Doesn't seem it's published
     # as a .sha265sum like for the linux .tar.gz
-    download = "#{uri}/content/habitat/stable/windows/x86_64/#{package_name}.zip?bt_package=hab-x86_64-windows"
+    download = "#{uri}/stable/habitat/latest/hab-x86_64-windows.zip"
 
     remote_file zipfile do
       source download


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

Corrects windows hab package download location to use packages.chef.io

### Issues Resolved

#197 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
