### PR TITLE
adding delay loop to the load function in the service resouce

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -233,7 +233,13 @@ action :load do
     options << '--force'
   end
 
-  execute "hab svc load #{new_resource.service_name} #{options.join(' ')}" unless current_resource.loaded && !modified
+  unless current_resource.loaded && !modified
+    execute 'test' do
+      command "hab svc load #{new_resource.service_name} #{options.join(' ')}"
+      retry_delay 10
+      retries 5
+    end
+  end
 end
 
 action :unload do


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

Quick fix to the service resource due to a loading issue. 

[Describe what this change achieves]

Seeing issues in non-chef owned pipelines where services aren't loading fast enough so it is causing a false failure in the pipeline. When the delay is added, everything works as expected.

This minor fix is working in customer pipeline properly now.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
