### PR TITLE
Extending Windows chef-client compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,12 @@
 
 This file is used to list changes made in each version of the habitat cookbook.
 
-## 1.5.4 (2020-02-25)
-
-- correct package name for the windows zip file being used. also added a step to create c:\habitat directory since powershell was failing on that step. placeholder for upgrade enhancement - [@sam1el](https://github.com/sam1el)
-- [BUG_FIX] Issue #199 fixeed install on Windows - [@sam1el](https://github.com/sam1el)
-- removing unwanted tests - [@sam1el](https://github.com/sam1el)
-- fixed bad syntax in install resource - [@sam1el](https://github.com/sam1el)
-- Remove a bogus platform_family? check - [@tas50](https://github.com/tas50)
-- Remove old Foodcritic comments - [@tas50](https://github.com/tas50)
-- Add testing with Github Actions - [@tas50](https://github.com/tas50)
-- Update systems we test on in Test Kitchen - [@tas50](https://github.com/tas50)
-- Allow versions in the specs to float a bit - [@tas50](https://github.com/tas50)
-- Remove the .foodcritic file - [@tas50](https://github.com/tas50)
-- Update the boxes in Kitchen and the Travis config - [@tas50](https://github.com/tas50)
-- Remove github actions for now - [@tas50](https://github.com/tas50)
-- Use public windows boxes and fix travis failures - [@tas50](https://github.com/tas50)
-- Run delivery in Github Actions - [@tas50](https://github.com/tas50)
-- Disable cookstyle for old spec - [@tas50](https://github.com/tas50)
-- Update CHANGELOG.md with details from pull request #189
-- removed bad unit test - [@sam1el](https://github.com/sam1el)
-- fixing delivery errors (#6) - [@sam1el](https://github.com/sam1el)
-- [BUG FIX] Windows install to correct issue #199 (#202) - [@sam1el](https://github.com/sam1el)
-- Update CHANGELOG.md with details from pull request #202
-- Release 1.15.2 - [@jonlives](https://github.com/jonlives)
-- Merge branch 'master' of github.com:chef-cookbooks/habitat - [@sam1el](https://github.com/sam1el)
-- correction to systemd template - [@sam1el](https://github.com/sam1el)
-- corrected the broken unit test for sup_spec.rb to match the new systemd template - [@sam1el](https://github.com/sam1el)
-- fixed broken syntax in resourece/service.rb line 236-237 - [@sam1el](https://github.com/sam1el)
-- extended the delay on a few service tests to allow more time to load - [@sam1el](https://github.com/sam1el)
-- bumped hab version to newest stable - [@sam1el](https://github.com/sam1el)
-- reverted back to 1.5.0 and removed 2 settings from systemd - [@sam1el](https://github.com/sam1el)
-- removed unwanted systemd test - [@sam1el](https://github.com/sam1el)
-- changing kernel detection syntax to to_i rather then to_f - [@sam1el](https://github.com/sam1el)
-- corrected integers in the install and hab_packaged provider resources for the kernel version check - [@sam1el](https://github.com/sam1el)
-- Update CHANGELOG.md with details from pull request #203
-- Releasing 1.5.3 - [@jonlives](https://github.com/jonlives)
-- adding delay loop to the load function in the service resouce - [@sam1el](https://github.com/sam1el)
-- Update CHANGELOG.md with details from pull request #204
 <!-- latest_release unreleased -->
 ## Unreleased
+
+## 1.5.4 (2020-02-25)
+
+- adding delay loop to the load function in the service resouce - [@sam1el](https://github.com/sam1el)
 
 #### Merged Pull Requests
 - adding delay loop to the load function in the service resouce [#204](https://github.com/chef-cookbooks/habitat/pull/204) ([sam1el](https://github.com/sam1el))

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,7 +21,7 @@ require 'chef/http/simple'
 
 resource_name :hab_install
 
-property :name, String, default: '' # ~FC108 This allows for bare names like hab_install
+property :name, String, default: ''
 # The following are only used on *nix
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
 property :bldr_url, String
@@ -62,14 +62,14 @@ action :install do
           end
         end
         action :run
-        not_if { Dir.exist?('c:\habitat') }
+        not_if { ::Dir.exist?('c:\habitat') }
       end
     else
       archive_file "#{package_name}.zip" do
         path zipfile
         destination "#{Chef::Config[:file_cache_path]}/habitat"
         action :extract
-        not_if { Dir.exist?('c:\habitat') }
+        not_if { ::Dir.exist?('c:\habitat') }
       end
     end
 
@@ -137,7 +137,7 @@ action :upgrade do
     end
 
     if Chef::VERSION < 15
-      ruby_block 'name' do
+      ruby_block "#{package_name}.zip" do
         block do
           require 'zip'
           Zip::File.open(zipfile) do |zip_file|
@@ -201,7 +201,7 @@ action_class do
   end
 
   def hab_command
-    cmd = if node['kernel']['release'].to_f < 3.0
+    cmd = if node['kernel']['release'].to_i < 3
             ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", "-v #{hab_version} -t x86_64-linux-kernel2"]
           else
             ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", "-v #{hab_version}"]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,7 +21,7 @@ require 'chef/http/simple'
 
 resource_name :hab_install
 
-property :name, String, default: ''
+property :name, String, default: '' # ~FC108 This allows for bare names like hab_install
 # The following are only used on *nix
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
 property :bldr_url, String
@@ -50,26 +50,38 @@ action :install do
       source download
     end
 
-    archive_file "#{package_name}.zip" do
-      path zipfile
-      destination "#{Chef::Config[:file_cache_path]}/habitat"
-      action :extract
+    if Chef::VERSION < 15
+      ruby_block "#{package_name}.zip" do
+        block do
+          require 'zip'
+          Zip::File.open(zipfile) do |zip_file|
+            zip_file.each do |f|
+              fpath = "#{Chef::Config[:file_cache_path]}/habitat/" + f.name
+              zip_file.extract(f, fpath) # unless ::File.exist?(fpath)
+            end
+          end
+        end
+        action :run
+        not_if { Dir.exist?('c:\habitat') }
+      end
+    else
+      archive_file "#{package_name}.zip" do
+        path zipfile
+        destination "#{Chef::Config[:file_cache_path]}/habitat"
+        action :extract
+        not_if { Dir.exist?('c:\habitat') }
+      end
     end
 
-    # Precreate 'c:\habitat to correct powershell errors'
-    # The powershell_script was just creating a file called habitat in 'c:/'
-    directory 'c:\habitat'
+    directory 'c:\habitat' do
+      notifies :run, 'powershell_script[installing from archive]', :immediately
+    end
 
     powershell_script 'installing from archive' do
       code <<-EOH
       Move-Item -Path #{Chef::Config[:file_cache_path]}/habitat/hab-*/* -Destination C:/habitat -Force
       EOH
-    end
-
-    # Cleanup for future upgrade purposes
-    directory "#{Chef::Config[:file_cache_path]}/habitat" do
-      action :delete
-      recursive true
+      action :nothing
     end
 
     # TODO: This won't self heal if missing until the next upgrade
@@ -124,11 +136,25 @@ action :upgrade do
       source download
     end
 
-    archive_file "#{package_name}.zip" do
-      path zipfile
-      destination "#{Chef::Config[:file_cache_path]}/habitat"
-      overwrite true
-      action :extract
+    if Chef::VERSION < 15
+      ruby_block 'name' do
+        block do
+          require 'zip'
+          Zip::File.open(zipfile) do |zip_file|
+            zip_file.each do |f|
+              fpath = "#{Chef::Config[:file_cache_path]}/habitat/" + f.name
+              zip_file.extract(f, fpath) # unless ::File.exist?(fpath)
+            end
+          end
+        end
+        action :run
+      end
+    else
+      archive_file "#{package_name}.zip" do
+        path zipfile
+        destination "#{Chef::Config[:file_cache_path]}/habitat"
+        action :extract
+      end
     end
 
     powershell_script 'installing from archive' do
@@ -175,7 +201,7 @@ action_class do
   end
 
   def hab_command
-    cmd = if node['kernel']['release'].to_i < 3
+    cmd = if node['kernel']['release'].to_f < 3.0
             ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", "-v #{hab_version} -t x86_64-linux-kernel2"]
           else
             ["bash #{Chef::Config[:file_cache_path]}/hab-install.sh", "-v #{hab_version}"]


### PR DESCRIPTION
### Description

This will allow habitat to be installed with chef-client 12+ in support of upgrading customers to effortless as well as deploying habitat in general. Also, added some idempotence to the install resource. 

### Issues Resolved

The install resource was not 100% idempotent on windows. that is now fixed. Added custom unzip function to allow older chef-client versions to decompress the zip archive on windows. 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
