### PR TITLE
updates to be backwards compatible with 12.20.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the habitat cookbook.
 
 ## Unreleased
+<!-- latest_release unreleased -->
 
 ## 1.5.8 (2020-03-09)
 

--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -32,13 +32,13 @@ class Chef
         # TODO: There has to be a better way to handle auth token on windows
         # than the system wide environment variable
         auth_action = new_resource.auth_token ? :create : :delete
-        windows_env 'HAB_AUTH_TOKEN' do
+        env 'HAB_AUTH_TOKEN' do
           value new_resource.auth_token if new_resource.auth_token
           action auth_action
         end
 
         gateway_auth_action = new_resource.gateway_auth_token ? :create : :delete
-        windows_env 'HAB_SUP_GATEWAY_AUTH_TOKEN' do
+        env 'HAB_SUP_GATEWAY_AUTH_TOKEN' do
           value new_resource.gateway_auth_token if new_resource.gateway_auth_token
           action gateway_auth_action
         end
@@ -60,8 +60,8 @@ class Chef
         end
 
         service 'Habitat' do
-          subscribes :restart, 'windows_env[HAB_AUTH_TOKEN]'
-          subscribes :restart, 'windows_env[HAB_SUP_GATEWAY_AUTH_TOKEN]'
+          subscribes :restart, 'env[HAB_AUTH_TOKEN]'
+          subscribes :restart, 'env[HAB_SUP_GATEWAY_AUTH_TOKEN]'
           subscribes :restart, 'template[C:/hab/svc/windows-service/HabService.exe.config]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,5 +13,3 @@ version           '1.5.8'
 end
 
 gem 'toml-rb'
-
-depends 'windows'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -50,7 +50,11 @@ action :install do
       source download
     end
 
-    if Chef::VERSION < 15
+    if Chef::VERSION.to_i < 15
+      chef_gem 'rubyzip' do
+        compile_time false
+        version '< 2.0.0'
+      end
       ruby_block "#{package_name}.zip" do
         block do
           require 'zip'
@@ -85,8 +89,16 @@ action :install do
     end
 
     # TODO: This won't self heal if missing until the next upgrade
-    windows_path 'C:\habitat' do
-      action :add
+    if Chef::VERSION.to_i < 14
+      env 'PATH_c-habitat' do
+        key_name 'PATH'
+        value 'C:\habitat'
+        action :modify
+      end
+    else
+      windows_path 'C:\habitat' do
+        action :add
+      end
     end
   else
     package %w(curl tar gzip)
@@ -136,7 +148,7 @@ action :upgrade do
       source download
     end
 
-    if Chef::VERSION < 15
+    if Chef::VERSION.to_i < 15
       ruby_block "#{package_name}.zip" do
         block do
           require 'zip'
@@ -164,8 +176,16 @@ action :upgrade do
     end
 
     # TODO: This won't self heal if missing until the next upgrade
-    windows_path 'C:\habitat' do
-      action :add
+    if Chef::VERSION.to_i < 14
+      env 'PATH_c-habitat' do
+        key_name 'PATH'
+        value 'C:\habitat'
+        action :modify
+      end
+    else
+      windows_path 'C:\habitat' do
+        action :add
+      end
     end
   else
     remote_file ::File.join(Chef::Config[:file_cache_path], 'hab-install.sh') do

--- a/test/integration/win-user-toml/default_spec.rb
+++ b/test/integration/win-user-toml/default_spec.rb
@@ -3,7 +3,6 @@ describe file('C:\habitat\hab.exe') do
 end
 
 splunkforwarder_content = <<-EOF
-
 [directories]
 path = ["C:/hab/pkgs/.../*.log"]
 EOF


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

Updates to be backwards-compatible with previous stable releases of Chef Infra client for assisting with upgrade and migration paths to Habitat and/or the Effortless pattern.  Addresses issue #213 

For testing purposes, created a combined test suite from the following and ran for component testing:

* win-config
* win-package
* win-service
* win-sup
* win-user-toml

| version | status |
| --- | --- |
| 12.20.3 | ✔ |
| 12.22.5 | ✔ |
| 13.2.20 | ✔ |
| 13.3.42 | ✔ |
| 13.12.3 | ✔ |
| 14.14.29 | ✔ |
| 15.8.23 | ✔ |

Sample Test Result Data:

```
Target:  winrm://vagrant@http://127.0.0.1:55985/wsman:3389

  File C:\habitat\hab.exe
     ✔  is expected to exist
  Command: `C:\habitat\hab.exe -V`
     ✔  stdout is expected to match /^hab 1.5.71\//
     ✔  exit_status is expected to eq 0
  Powershell
     ✔  stdout is expected to match /\{\"directories\":\{\"path\":\[\"C:\/hab\/pkgs\/...\/\*\.log\"\]\}\}/
  File C:\hab\accepted-licenses\habitat
     ✔  is expected to exist
  Directory C:\hab\pkgs\skylerto\splunkforwarder
     ✔  is expected to exist
  Command: `C:\habitat\hab.exe pkg path skylerto/splunkforwarder`
     ✔  exit_status is expected to eq 0
     ✔  stdout is expected to match /C:\\hab\\pkgs\\skylerto\\splunkforwarder/
  Port 9631
     ✔  is expected to be listening
  File /hab/user/splunkforwarder/config/user.toml
     ✔  is expected to exist
     ✔  content is expected to match "[directories]\r\npath = [\"C:/hab/pkgs/.../*.log\"]\r\n"

Test Summary: 14 successful, 0 failures, 0 skipped
       Finished verifying <win-user-toml-windows-2016> (0m12.68s).
-----> Test Kitchen is finished. (0m14.31s)
```

### Issues Resolved
<!--- List any existing issues this PR resolves -->
#213 

### Check List

- [ X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X ] New functionality includes testing.
- [ X ] New functionality has been documented in the README if applicable
- [ X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>