### PR TITLE
adding --update-condition funtionality that was added in habitat 1.5.71

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ The follow properties are valid for the `load` action.
 - `loaded`: state property indicating whether the service is loaded in the supervisor
 - `running`: state property indicating whether the service is running in the supervisor
 - `strategy`: Passes `--strategy` with the specified update strategy to the hab command
-- `update_condition`: Passes `--update-condition` with the specified roll-back strategy. Defaults to `latest`. Options are `latest` or `track-channel`
+- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel`
+  - `latest`: Runs the latest package that can be found in the configured channel and local packages.
+  - `track-channel`: Always run what is at the head of a given channel. This enables service rollback where demoting a package from a channel will cause the package to rollback to an older version of the package. A ramification of enabling this condition is packages newer than the package at the head of the channel will be automatically uninstalled during a service rollback.
 - `topology`: Passes `--topology` with the specified service topology to the hab command
 - `bldr_url`: Passes `--url` with the specified Builder URL to the hab command.
 - `channel`: Passes `--channel` with the specified channel to the hab command
@@ -238,7 +240,9 @@ All `event_stream_*` properties are optional, and allow the Habitat Supervisor t
 - `peer`: Only valid for `:run` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `auto_update`: Passes `--auto-update`. This will set the Habitat supervisor to automatically update itself any time a stable version has been released
-- `update_condition`: Passes `--update-condition` with the specified roll-back strategy. Defaults to `latest`. Options are `latest` or `track-channel`
+- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel`
+  - `latest`: Runs the latest package that can be found in the configured channel and local packages.
+  - `track-channel`: Always run what is at the head of a given channel. This enables service rollback where demoting a package from a channel will cause the package to rollback to an older version of the package. A ramification of enabling this condition is packages newer than the package at the head of the channel will be automatically uninstalled during a service rollback.
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
 - `gateway_auth_token`: Auth token for accessing the supervisor's HTTP gateway. This value is templated into the appropriate service file.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The follow properties are valid for the `load` action.
 - `loaded`: state property indicating whether the service is loaded in the supervisor
 - `running`: state property indicating whether the service is running in the supervisor
 - `strategy`: Passes `--strategy` with the specified update strategy to the hab command
+- `update_condition`: Passes `--update-condition` with the specified roll-back strategy. Defaults to `latest`. Options are `latest` or `track-channel`
 - `topology`: Passes `--topology` with the specified service topology to the hab command
 - `bldr_url`: Passes `--url` with the specified Builder URL to the hab command.
 - `channel`: Passes `--channel` with the specified channel to the hab command
@@ -190,6 +191,12 @@ end
 # pass the strategy and topology options to hab service commands (load by default)
 hab_service 'core/redis' do
   strategy 'rolling'
+  topology 'standalone'
+end
+
+hab_service 'core/redis' do
+  strategy 'rolling'
+  update_condition 'track-channel'
   topology 'standalone'
 end
 ```
@@ -230,6 +237,8 @@ All `event_stream_*` properties are optional, and allow the Habitat Supervisor t
 - `org`: Only valid for `:run` action, passes `--org` with the specified org name to the hab command
 - `peer`: Only valid for `:run` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
+- `auto_update`: Passes `--auto-update`. This will set the Habitat supervisor to automatically update itself any time a stable version has been released
+- `update_condition`: Passes `--update-condition` with the specified roll-back strategy. Defaults to `latest`. Options are `latest` or `track-channel`
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
 - `auth_token`: Auth token for accessing a private organization on bldr. This value is templated into the appropriate service file.
 - `gateway_auth_token`: Auth token for accessing the supervisor's HTTP gateway. This value is templated into the appropriate service file.

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,6 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
   chef_license: accept-no-persist
 
 transport:

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -36,6 +36,7 @@ class Chef
       property :auto_update, [true, false], default: false
       property :auth_token, String
       property :gateway_auth_token, String
+      property :update_condition, String, default: 'latest'
       property :limit_no_files, String
       property :license, String, equal_to: ['accept']
       property :health_check_interval, coerce: proc { |h| h.is_a?(String) ? h : h.to_s }
@@ -74,6 +75,7 @@ class Chef
           opts.push(*new_resource.peer.map { |b| "--peer #{b}" }) if new_resource.peer
           opts << "--ring #{new_resource.ring}" if new_resource.ring
           opts << '--auto-update' if new_resource.auto_update
+          opts << "--update-condition #{new_resource.update_condition}" if new_resource.update_condition
           opts << "--health-check-interval #{new_resource.health_check_interval}" if new_resource.health_check_interval
           opts << "--event-stream-application #{new_resource.event_stream_application}" if new_resource.event_stream_application
           opts << "--event-stream-environment #{new_resource.event_stream_environment}" if new_resource.event_stream_environment

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,7 +21,7 @@ require 'chef/http/simple'
 
 resource_name :hab_install
 
-property :name, String, default: '' # ~FC108ß
+property :name, String, default: '' # ~FC108
 # The following are only used on *nix
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'
 property :bldr_url, String
@@ -132,7 +132,7 @@ action :install do
   execute 'hab license accept' if new_resource.license == 'accept'
 end
 
-# TODO: What is the point of the upgrade action? We are version locking and the install action safely handles upgrades.
+# TODO: Work out how to unfreeze the versions safely
 action :upgrade do
   if platform_family?('windows')
     # Retrieve version information

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -142,7 +142,7 @@ rescue
 end
 
 def get_update_condition(service_details)
-  service_details['health_check_interval']['secs']
+  service_details['update_condition']['secs']
 rescue
   Chef::Log.debug("Update condition #{service_name} not found on Supervisor API")
   'latest'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -34,6 +34,7 @@ property :remote_sup, String, default: '127.0.0.1:9632', desired_state: false
 # Http port needed for querying/comparing current config value
 property :remote_sup_http, String, default: '127.0.0.1:9631', desired_state: false
 property :gateway_auth_token, String, desired_state: false
+property :update_condition, String, default: 'latest'
 
 load_current_value do
   service_details = get_service_details(service_name)
@@ -44,6 +45,7 @@ load_current_value do
   if loaded
     service_name get_spec_identifier(service_details)
     strategy get_update_strategy(service_details)
+    update_condition get_update_condition(service_details)
     topology get_topology(service_details)
     bldr_url get_builder_url(service_details)
     channel get_channel(service_details)
@@ -58,6 +60,7 @@ load_current_value do
   Chef::Log.debug("service #{service_name} running state: #{running}")
   Chef::Log.debug("service #{service_name} loaded state: #{loaded}")
   Chef::Log.debug("service #{service_name} strategy: #{strategy}")
+  Chef::Log.debug("service #{service_name} update condition: #{update_condition}")
   Chef::Log.debug("service #{service_name} topology: #{topology}")
   Chef::Log.debug("service #{service_name} builder url: #{bldr_url}")
   Chef::Log.debug("service #{service_name} channel: #{channel}")
@@ -138,6 +141,13 @@ rescue
   'none'
 end
 
+def get_update_condition(service_details)
+  service_details['health_check_interval']['secs']
+rescue
+  Chef::Log.debug("Update condition #{service_name} not found on Supervisor API")
+  'latest'
+end
+
 def get_topology(service_details)
   service_details['topology'].to_sym
 rescue
@@ -200,6 +210,9 @@ action :load do
     modified = true
   end
   converge_if_changed :strategy do
+    modified = true
+  end
+  converge_if_changed :update_condition do
     modified = true
   end
   converge_if_changed :topology do
@@ -293,6 +306,7 @@ action_class do
       opts << "--channel #{new_resource.channel}" if new_resource.channel
       opts << "--group #{new_resource.service_group}" if new_resource.service_group
       opts << "--strategy #{new_resource.strategy}" if new_resource.strategy
+      opts << "--update-condition #{new_resource.update_condition}" if new_resource.update_condition
       opts << "--topology #{new_resource.topology}" if new_resource.topology
       opts << "--health-check-interval #{new_resource.health_check_interval}" if new_resource.health_check_interval
       opts << "--shutdown-timeout #{new_resource.shutdown_timeout}" if new_resource.shutdown_timeout

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -43,6 +43,7 @@ describe 'test::service' do
         channel: :'bldr-1321420393699319808',
         topology: :standalone,
         strategy: :'at-once',
+        update_condition: 'latest',
         binding_mode: :relaxed,
         shutdown_timeout: 10,
         health_check_interval: 32

--- a/spec/unit/sup_spec.rb
+++ b/spec/unit/sup_spec.rb
@@ -89,7 +89,7 @@ describe 'test::sup' do
             },
             Service: {
               Environment: [],
-              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
+              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
               ExecStop: '/bin/hab sup term',
               Restart: 'on-failure',
             },
@@ -138,7 +138,7 @@ describe 'test::sup' do
           group: 'root',
           mode: '0644',
           variables: {
-            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
+            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
             auth_token: nil,
             gateway_auth_token: nil,
           }
@@ -184,7 +184,7 @@ describe 'test::sup' do
           mode: '0755',
           variables: {
             name: 'hab-sup',
-            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
+            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
             auth_token: nil,
             gateway_auth_token: nil,
           }

--- a/templates/windows/HabService.exe.config.erb
+++ b/templates/windows/HabService.exe.config.erb
@@ -1,28 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
-  </configSections>
-  <startup>
-    <supportedRuntime version="v4.0.30319"/>
-  </startup>
-  <log4net>
-    <root>
-      <level value="ALL" />
-      <appender-ref ref="RollingFileAppender" />
-    </root>
-    <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="logs\Habitat.log" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="100MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date - %message%newline" />
-      </layout>
-    </appender>
-  </log4net>
   <appSettings>
     <add key="debug" value="false" />
     <add key="HAB_FEAT_IGNORE_SIGNALS" value="true" />

--- a/test/fixtures/cookbooks/test/recipes/service.rb
+++ b/test/fixtures/cookbooks/test/recipes/service.rb
@@ -49,6 +49,7 @@ hab_package 'core/redis'
 hab_service 'core/redis' do
   strategy :rolling
   topology :standalone
+  update_condition 'latest'
   channel :stable
 end
 
@@ -127,6 +128,7 @@ hab_service 'core/grafana property change from defaults' do
   service_group 'test-1'
   bldr_url 'https://bldr-test-1.habitat.sh'
   strategy 'rolling'
+  update_condition 'latest'
   shutdown_timeout 9
   health_check_interval 31
 end
@@ -139,6 +141,7 @@ hab_service 'core/grafana property change from custom values' do
   channel 'bldr-1321420393699319808'
   topology :standalone
   strategy :'at-once'
+  update_condition 'latest'
   binding_mode :relaxed
   shutdown_timeout 10
   health_check_interval 32
@@ -166,6 +169,7 @@ hab_service 'core/grafana binding' do
   channel 'bldr-1321420393699319808'
   topology :standalone
   strategy :'at-once'
+  update_condition 'latest'
   bind 'prom:prometheus.default'
   binding_mode :relaxed
   shutdown_timeout 10

--- a/test/fixtures/cookbooks/test/recipes/win_service.rb
+++ b/test/fixtures/cookbooks/test/recipes/win_service.rb
@@ -30,6 +30,7 @@ end
 
 hab_service 'ncr_devops_platform/sensu-agent-win' do
   strategy 'rolling'
+  update_condition 'latest'
   channel :stable
   action :load
 end

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -22,6 +22,7 @@ describe file('/hab/sup/default/specs/grafana.spec') do
   its(:content) { should match(/channel = "bldr-1321420393699319808"/) }
   its(:content) { should match(/topology = "standalone"/) }
   its(:content) { should match(/update_strategy = "at-once"/) }
+  its(:content) { should match(/update_condition = "latest"/) }
   its(:content) { should match(/binds = \["prom:prometheus.default"\]/) }
   its(:content) { should match(/binding_mode = "relaxed"/) }
   its(:content) { should match(/shutdown_timeout = 10/) }


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

### Description
This adds the new function that allows the `hab_sup` and `hab_service` resource to set a `roll-back strategy`

Additional info

--update-condition <UPDATE_CONDITION>
The condition dictating when this service should updated

`latest`: Runs the latest package that can be found in the configured channel and local packages.

`track-channel`: Always run what is at the head of a given channel. This enables service rollback where demoting a package from a channel will cause the package to rollback to an older version of the package. A ramification of enabling this condition is packages newer than the package at the head of the channel will be automatically uninstalled during a service rollback. [default: latest]  [possible values: latest, track-channel]


### Issues Resolved

It addresses issues
+ #216 
+ #212 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>