### PR TITLE
removing update-confition defaults and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The follow properties are valid for the `load` action.
 - `loaded`: state property indicating whether the service is loaded in the supervisor
 - `running`: state property indicating whether the service is running in the supervisor
 - `strategy`: Passes `--strategy` with the specified update strategy to the hab command
-- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel`
+- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel` ***Note: This requires a minimum habitat version of 1.5.71***
   - `latest`: Runs the latest package that can be found in the configured channel and local packages.
   - `track-channel`: Always run what is at the head of a given channel. This enables service rollback where demoting a package from a channel will cause the package to rollback to an older version of the package. A ramification of enabling this condition is packages newer than the package at the head of the channel will be automatically uninstalled during a service rollback.
 - `topology`: Passes `--topology` with the specified service topology to the hab command
@@ -224,6 +224,7 @@ Runs a Habitat Supervisor for one or more Habitat Services. It is used in conjun
 The `run` action handles installing Habitat using the `hab_install` resource, ensures that the appropriate versions of the `core/hab-sup` and `core/hab-launcher` packages are installed using `hab_package`, and then drops off the appropriate init system definitions and manages the service.
 
 All `event_stream_*` properties are optional, and allow the Habitat Supervisor to display details about it's status and running services via the [Chef Automate Applications Dashboard](https://automate.chef.io/docs/applications-dashboard/).
+***Note: Automate has TLS on by default. You will need to follow these instructions to make sure habitat has the proper certificates for `event_stram_*` [Share the TLS Certificate with Chef Habitat](https://automate.chef.io/docs/applications-setup/#share-the-tls-certificate-with-chef-habitat)***
 
 #### Actions
 
@@ -240,7 +241,7 @@ All `event_stream_*` properties are optional, and allow the Habitat Supervisor t
 - `peer`: Only valid for `:run` action, passes `--peer` with the specified initial peer to the hab command
 - `ring`: Only valid for `:run` action, passes `--ring` with the specified ring key name to the hab command
 - `auto_update`: Passes `--auto-update`. This will set the Habitat supervisor to automatically update itself any time a stable version has been released
-- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel`
+- `update_condition`: Passes `--update-condition` dictating when this service should updated. Defaults to `latest`. Options are `latest` or `track-channel`  ***Note: This requires a minimum habitat version of 1.5.71***
   - `latest`: Runs the latest package that can be found in the configured channel and local packages.
   - `track-channel`: Always run what is at the head of a given channel. This enables service rollback where demoting a package from a channel will cause the package to rollback to an older version of the package. A ramification of enabling this condition is packages newer than the package at the head of the channel will be automatically uninstalled during a service rollback.
 - `hab_channel`: The channel to install Habitat from. Defaults to stable
@@ -253,6 +254,7 @@ All `event_stream_*` properties are optional, and allow the Habitat Supervisor t
 - `event_stream_site`: Application Dashboard label for the "site" of the application - can be filtered in the dashboard
 - `event_stream_url`: `AUTOMATE_HOSTNAME:4222` - the Chef Automate URL with port 4222 specified (can be changed if needed)
 - `event_stream_token`: Chef Automate token for sending application event stream data
+- `event_stream__certificate` [] ***This will be added in the next release*** - JB 04/07/20
 
 #### Examples
 

--- a/libraries/resource_hab_sup.rb
+++ b/libraries/resource_hab_sup.rb
@@ -36,7 +36,7 @@ class Chef
       property :auto_update, [true, false], default: false
       property :auth_token, String
       property :gateway_auth_token, String
-      property :update_condition, String, default: 'latest'
+      property :update_condition, String
       property :limit_no_files, String
       property :license, String, equal_to: ['accept']
       property :health_check_interval, coerce: proc { |h| h.is_a?(String) ? h : h.to_s }

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -34,7 +34,7 @@ property :remote_sup, String, default: '127.0.0.1:9632', desired_state: false
 # Http port needed for querying/comparing current config value
 property :remote_sup_http, String, default: '127.0.0.1:9631', desired_state: false
 property :gateway_auth_token, String, desired_state: false
-property :update_condition, String, default: 'latest'
+property :update_condition, String
 
 load_current_value do
   service_details = get_service_details(service_name)

--- a/spec/unit/sup_spec.rb
+++ b/spec/unit/sup_spec.rb
@@ -89,7 +89,7 @@ describe 'test::sup' do
             },
             Service: {
               Environment: [],
-              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
+              ExecStart: '/bin/hab sup run --listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
               ExecStop: '/bin/hab sup term',
               Restart: 'on-failure',
             },
@@ -138,7 +138,7 @@ describe 'test::sup' do
           group: 'root',
           mode: '0644',
           variables: {
-            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
+            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
             auth_token: nil,
             gateway_auth_token: nil,
           }
@@ -184,7 +184,7 @@ describe 'test::sup' do
           mode: '0755',
           variables: {
             name: 'hab-sup',
-            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3 --update-condition latest',
+            exec_start_options: '--listen-gossip 0.0.0.0:7998 --listen-http 0.0.0.0:7999 --peer 127.0.0.2 --peer 127.0.0.3',
             auth_token: nil,
             gateway_auth_token: nil,
           }


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

Removing the default variable setting for `--update-condition`

### Description

Stops forcing a value which causes an older hab install to break

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>