### PR TITLE
changing the windows service cofig to better reflect newer functional…

### DIFF
--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -55,7 +55,10 @@ class Chef
         template 'C:/hab/svc/windows-service/HabService.exe.config' do
           source 'windows/HabService.exe.config.erb'
           cookbook 'habitat'
-          variables(exec_start_options: exec_start_options)
+          variables exec_start_options: exec_start_options,
+                    bldr_url: new_resource.bldr_url,
+                    auth_token: new_resource.auth_token,
+                    gateway_auth_token: new_resource.gateway_auth_token
           action :create
         end
 

--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -71,6 +71,7 @@ class Chef
         service 'Habitat' do
           subscribes :restart, 'env[HAB_AUTH_TOKEN]'
           subscribes :restart, 'env[HAB_SUP_GATEWAY_AUTH_TOKEN]'
+          subscribes :restart, 'env[HAB_BLDR_URL]'
           subscribes :restart, 'template[C:/hab/svc/windows-service/HabService.exe.config]'
           subscribes :restart, 'hab_package[core/hab-sup]'
           subscribes :restart, 'hab_package[core/hab-launcher]'

--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -43,6 +43,12 @@ class Chef
           action gateway_auth_action
         end
 
+        bldr_action = new_resource.bldr_url ? :create : :delete
+        env 'HAB_BLDR_URL' do
+          value new_resource.bldr_url if new_resource.bldr_url
+          action bldr_action
+        end
+
         hab_package 'core/windows-service' do
           bldr_url new_resource.bldr_url if new_resource.bldr_url
           version hab_windows_service_version

--- a/templates/windows/HabService.exe.config.erb
+++ b/templates/windows/HabService.exe.config.erb
@@ -3,9 +3,15 @@
   <appSettings>
     <add key="debug" value="false" />
     <add key="maximumFilesize" value="2kb" />
+    <% if @auth_token %>
     <add key="ENV_HAB_AUTH_TOKEN" value="<%= @auth_token %>" />
+    <% end %>
+    <% if @gateway_auth_token %>
     <add key="ENV_HAB_SUP_GATEWAY_AUTH_TOKEN" value="<%= @gateway_auth_token %>" />
+    <% end %>
+    <% if @bldr_url %>
     <add key="ENV_HAB_BLDR_URL" value="<%= @bldr_url %>" />
+    <% end %>
     <add key="launcherArgs" value="--no-color <%= @exec_start_options %>" />
   </appSettings>
 </configuration>

--- a/templates/windows/HabService.exe.config.erb
+++ b/templates/windows/HabService.exe.config.erb
@@ -2,7 +2,10 @@
 <configuration>
   <appSettings>
     <add key="debug" value="false" />
-    <add key="HAB_FEAT_IGNORE_SIGNALS" value="true" />
+    <add key="maximumFilesize" value="2kb" />
+    <add key="ENV_HAB_AUTH_TOKEN" value="<%= @auth_token %>" />
+    <add key="ENV_HAB_SUP_GATEWAY_AUTH_TOKEN" value="<%= @gateway_auth_token %>" />
+    <add key="ENV_HAB_BLDR_URL" value="<%= @bldr_url %>" />
     <add key="launcherArgs" value="--no-color <%= @exec_start_options %>" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

added ability to set ENV variables in service config

### Description
The newer version of the windows-service for habitat allows for the setting of `HAB_BLDR_URL`, `HAB_AUTH_TOKEN`, etc. as part of the service configuration file. 

3 of them have been implemented in this iteration 

```!#/bin/xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <appSettings>
    <add key="debug" value="false" />
    <add key="maximumFilesize" value="2kb" />
    <add key="ENV_HAB_AUTH_TOKEN" value="<%= @auth_token %>" />
    <add key="ENV_HAB_SUP_GATEWAY_AUTH_TOKEN" value="<%= @gateway_auth_token %>" />
    <add key="ENV_HAB_BLDR_URL" value="<%= @bldr_url %>" />
    <add key="launcherArgs" value="--no-color <%= @exec_start_options %>" />
  </appSettings>
</configuration>
```

### Issues Resolved

#212 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>