### PR TITLE
fix for windows-launcher config

### DIFF
--- a/libraries/resource_hab_sup_windows.rb
+++ b/libraries/resource_hab_sup_windows.rb
@@ -61,26 +61,17 @@ class Chef
           not_if { ::Win32::Service.exists?('Habitat') }
         end
 
-        if ::File.exist?('C:/habitat/hab.exe')
-          win_version = `hab pkg list core/hab-launcher`.split().last
+        # win_version = `dir /D /B C:\\hab\\pkgs\\core\\hab-launcher`.split().last
 
-          # ruby_block 'name' do
-          #   block do
-          #     win_version = `hab pkg list core/hab-launcher`.split().last
-          #     node.run_state['version'] = win_version
-          #   end
-          # end
-
-          template win_service_config.to_s do
-            source service_file.to_s
-            cookbook 'habitat'
-            variables exec_start_options: exec_start_options,
-                      bldr_url: new_resource.bldr_url,
-                      auth_token: new_resource.auth_token,
-                      gateway_auth_token: new_resource.gateway_auth_token,
-                      win_launcher: win_version
-            action :create
-          end
+        template win_service_config.to_s do
+          source service_file.to_s
+          cookbook 'habitat'
+          variables exec_start_options: exec_start_options,
+                    bldr_url: new_resource.bldr_url,
+                    auth_token: new_resource.auth_token,
+                    gateway_auth_token: new_resource.gateway_auth_token
+          # win_launcher: win_version
+          action :touch
         end
 
         service 'Habitat' do

--- a/templates/windows/HabService.dll.config.erb
+++ b/templates/windows/HabService.dll.config.erb
@@ -12,7 +12,9 @@
     <% if @bldr_url %>
     <add key="ENV_HAB_BLDR_URL" value="<%= @bldr_url %>" />
     <% end %>
+    <%if  @exec_start_options %>
     <add key="launcherArgs" value="--no-color <%= @exec_start_options %>" />
-    <add key="launcherPath" value="C:\Hab\pkgs\<%= @win_launcher %>\bin\hab-launch.exe"/>
+    <% end %>
+    <add key="launcherPath" value="C:\Hab\pkgs\<%= `hab pkg list core/hab-launcher`.split().last %>\bin\hab-launch.exe"/>
   </appSettings>
 </configuration>

--- a/test/integration/win_sup/default_spec.rb
+++ b/test/integration/win_sup/default_spec.rb
@@ -15,10 +15,10 @@ describe powershell(restart_script) do
 end
 
 # Removing these two tests temporarily, this needs to be validated and rewritten with the fixture then tested
-describe port(9631) do
+describe port(9998) do
   it { should be_listening }
 end
 
-describe port(9632) do
+describe port(9999) do
   it { should be_listening }
 end


### PR DESCRIPTION
Signed-off-by: Jeff Brimager <jbrimager@chef.io>

Changes that allow the windows-service to be completely controlled by the user. 

### Description
Previously, the windows-service wasn't being configured correctly. We were able to temporarly create a method to allow for some configuration but, wasn't able to dynamically see the launcher version to be configured correctly. Due to this, any upgrades to the launcher would cause a failure when the service was restarted. 
We were able to make the template more dynamic so that, upon initial install it will create the config with the correct launcher path and will also update correctly when upgraded.

### Issues Resolved
#212
#218 
- correcting launcher path issue (#13) - [@sam1el](https://github.com/sam1el)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>