### PR TITLE
updates custom resources to add resource_name

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -16,6 +16,7 @@
 require 'net/http'
 require 'json'
 
+resource_name :hab_config
 provides :hab_config
 
 property :config, Mash,

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -19,6 +19,7 @@
 #
 require 'chef/http/simple'
 
+resource_name :hab_install
 provides :hab_install
 
 property :name, String, default: ''

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+resource_name :hab_service
 provides :hab_service
 
 property :service_name, String, name_property: true

--- a/resources/user_toml.rb
+++ b/resources/user_toml.rb
@@ -11,6 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing
+resource_name :hab_user_toml
 provides :hab_user_toml
 
 property :config, Mash,


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
Addresses issue #245 Custom resources only had `provides` block without `resource_name`, which was fine for pre-v16.2 of Chef Infra client, but since the resource file names do not match the resource name, `resource_name` needs to be added in as well.

### Issues Resolved
<!--- List any existing issues this PR resolves -->
#245 
Issue only appears when calling Habitat cookbook using a wrapper cookbook.  Confirmed with local testing that issue is resolved with these changes.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>