### PR TITLE
Fixed hab_service flapping on bldr_url and update_condition

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -24,7 +24,7 @@ property :running, [true, false], default: false
 # hab svc options which get included based on the action of the resource
 property :strategy, [Symbol, String], equal_to: [:none, 'none', :'at-once', 'at-once', :rolling, 'rolling'], default: :none, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 property :topology, [Symbol, String], equal_to: [:standalone, 'standalone', :leader, 'leader'], default: :standalone, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
-property :bldr_url, String, default: 'https://bldr.habitat.sh'
+property :bldr_url, String, default: 'https://bldr.habitat.sh/'
 property :channel, [Symbol, String], default: :stable, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 property :bind, [String, Array], coerce: proc { |b| b.is_a?(String) ? [b] : b }, default: []
 property :binding_mode, [Symbol, String], equal_to: [:strict, 'strict', :relaxed, 'relaxed'], default: :strict, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
@@ -35,7 +35,7 @@ property :remote_sup, String, default: '127.0.0.1:9632', desired_state: false
 # Http port needed for querying/comparing current config value
 property :remote_sup_http, String, default: '127.0.0.1:9631', desired_state: false
 property :gateway_auth_token, String, desired_state: false
-property :update_condition, String
+property :update_condition, [Symbol, String], equal_to: [:latest, 'latest', :'track-channel', 'track-channel'], default: :latest, coerce: proc { |s| s.is_a?(String) ? s.to_sym : s }
 
 load_current_value do
   service_details = get_service_details(service_name)
@@ -143,7 +143,7 @@ rescue
 end
 
 def get_update_condition(service_details)
-  service_details['update_condition']['secs']
+  service_details['update_condition'].to_sym
 rescue
   Chef::Log.debug("Update condition #{service_name} not found on Supervisor API")
   'latest'

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -43,7 +43,7 @@ describe 'test::service' do
         channel: :'bldr-1321420393699319808',
         topology: :standalone,
         strategy: :'at-once',
-        update_condition: 'latest',
+        update_condition: :latest,
         binding_mode: :relaxed,
         shutdown_timeout: 10,
         health_check_interval: 32,

--- a/test/integration/service/default_spec.rb
+++ b/test/integration/service/default_spec.rb
@@ -18,7 +18,7 @@ grafanaserviceapi = 'curl -v -H "Authorization: Bearer secret" http://localhost:
 describe json(command: grafanaserviceapi) do
   its(['binding_mode']) { should eq 'relaxed' }
   its(['binds']) { should eq ['prom:prometheus.default'] }
-  its(['bldr_url']) { should eq 'https://bldr-test.habitat.sh' }
+  its(['bldr_url']) { should eq 'https://bldr-test.habitat.sh/' }
   its(['channel']) { should eq 'bldr-1321420393699319808' }
   its(%w(health_check_interval secs)) { should eq 32 }
   its(%w(pkg ident)) { should eq 'core/grafana/6.4.3/20191105024430' }

--- a/test/integration/win_service/default_spec.rb
+++ b/test/integration/win_service/default_spec.rb
@@ -20,7 +20,7 @@ $reply
 EOH
 
 describe json(command: servicecheck) do
-  its(['bldr_url']) { should eq 'https://bldr.habitat.sh' }
+  its(['bldr_url']) { should eq 'https://bldr.habitat.sh/' }
   its(%w(cfg id)) { should eq 'hab-sensu-agent' }
   its(%w(cfg backend-urls)) { should eq ['ws://127.0.0.1:8081'] }
   its(['channel']) { should eq 'stable' }


### PR DESCRIPTION
`bldr_url` defaulted to 'https://bldr.habitat.sh' but Habitat was
returning 'https://bldr.habitat.sh/', so it was marked changed with every
run.

`update_condition` did not have the proper string and symbol values and
default and the get_update_condition had been incorrectly looking for
`['secs']` instead of converting it to a symbol

Tested with hab 1.6.115/20200806220545 on Debian 10.

Signed-off-by: Matt Ray <github@mattray.dev>
