### PR TITLE
DRAFT: Fixes for test suites

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -87,7 +87,7 @@
           run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project chef-workstation
           shell: powershell
         - name: Add Chef Workstation to PATH
-          run: echo "##[add-path]C:\opscode\chef-workstation\bin\;"
+          run: $env:PATH = "C:\opscode\chef-workstation\bin\;" + $env:PATH
           shell: powershell
         - name: Chef Infra Client Run
           run: chef-solo -c test/solo.rb -o "test::${{ matrix.suite }}"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -6,15 +6,16 @@
     push:
       branches:
         - master
+        - main
 
   jobs:
     delivery:
       runs-on: ubuntu-latest
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Run Chef Delivery
-          uses: actionshub/chef-delivery@master
+          uses: actionshub/chef-delivery@main
           env:
             CHEF_LICENSE: accept-no-persist
 
@@ -53,11 +54,11 @@
 
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Install Chef
-          uses: actionshub/chef-install@master
+          uses: actionshub/chef-install@main
         - name: Dokken
-          uses: actionshub/kitchen-dokken@master
+          uses: actionshub/kitchen-dokken@main
           env:
             CHEF_LICENSE: accept-no-persist
             KITCHEN_LOCAL_YAML: kitchen.dokken.yml
@@ -82,7 +83,7 @@
         fail-fast: false
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Install Chef Workstation
           run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project chef-workstation
           shell: powershell


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

- Updates github delivery to reference `main` branch for action sources instead of `master`.
- Fixes Windows test suite path in `delivery.yml` for deprecated ##add-path.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>