### PR TITLE
pipeline testing updates

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -6,15 +6,16 @@
     push:
       branches:
         - master
+        - main
 
   jobs:
     delivery:
       runs-on: ubuntu-latest
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Run Chef Delivery
-          uses: actionshub/chef-delivery@master
+          uses: actionshub/chef-delivery@main
           env:
             CHEF_LICENSE: accept-no-persist
 
@@ -53,11 +54,11 @@
 
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Install Chef
-          uses: actionshub/chef-install@master
+          uses: actionshub/chef-install@main
         - name: Dokken
-          uses: actionshub/kitchen-dokken@master
+          uses: actionshub/kitchen-dokken@main
           env:
             CHEF_LICENSE: accept-no-persist
             KITCHEN_LOCAL_YAML: kitchen.dokken.yml
@@ -82,20 +83,26 @@
         fail-fast: false
       steps:
         - name: Check out code
-          uses: actions/checkout@master
+          uses: actions/checkout@main
         - name: Install Chef Workstation
           run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -channel stable -project chef-workstation
           shell: powershell
         - name: Add Chef Workstation to PATH
-          run: echo "##[add-path]C:\opscode\chef-workstation\bin\;"
+          run: |
+            if ( $env:PATH -like "*chef-workstation*" ) {
+              write-output 'Path already set, no action to perform'
+            } else {
+              write-output 'Adding c:\opscode\chef-workstation\bin to path.'
+              echo "c:\opscode\chef-workstation\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            }
           shell: powershell
         - name: Chef Infra Client Run
-          run: chef-solo -c test/solo.rb -o "test::${{ matrix.suite }}"
+          run: C:\opscode\chef-workstation\bin\chef-solo -c test/solo.rb -o "test::${{ matrix.suite }}"
           shell: powershell
           env:
             CHEF_LICENSE: accept-no-persist
         - name: Integration Testing
-          run: inspec exec test\integration\${{ matrix.suite }}\default_spec.rb
+          run: C:\opscode\chef-workstation\bin\inspec exec test\integration\${{ matrix.suite }}\default_spec.rb
           shell: powershell
           env:
             CHEF_LICENSE: accept-no-persist

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -50,6 +50,7 @@ platforms:
   driver:
     image: dokken/centos-6
     pid_one_command: /sbin/init
+    chef_version: 16.7 # patch for chef/chef:latest not working with el6
 
 - name: centos-7
   driver:
@@ -65,6 +66,7 @@ platforms:
   driver:
     image: dokken/oraclelinux-6
     pid_one_command: /sbin/init
+    chef_version: 16.7 # patch for chef/chef:latest not working with el6
 
 - name: oraclelinux-7
   driver:


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
Updates kitchen.dokken.yml with el6 patch and fixes PATH setting for Windows in github delivery.yml

### Issues Resolved
<!--- List any existing issues this PR resolves -->

* `[add-path]` function has been deprecated by GitHub and no longer works for Windows to set PATH data.  Updates to add items to `$env:GITHUB_PATH` instead.
* `el6` currently has an issue with using `chef/chef:latest` due to glibc compilation so pins `el6` instances to use `16.7` client version.
 
### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>