### PR TITLE
updates for unified_mode and adds EOL notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 [![CI State](https://github.com/chef-cookbooks/habitat/workflows/delivery/badge.svg)](https://github.com/chef-cookbooks/habitat/actions?query=workflow%3Adelivery)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
+## EOL Notice
+
+This cookbook is no longer required for configuring or managing Habitat configuration details with Chef Infra. The necessary resources and helpers are now built into Chef Infra Client itself as of Chef Infra Client `17.3`
+
+- [habitat_config](https://docs.chef.io/resources/habitat_config/)
+- [habitat_install](https://docs.chef.io/resources/habitat_install/)
+- [habitat_package](https://docs.chef.io/resources/habitat_package/)
+- [habitat_service](https://docs.chef.io/resources/habitat_service/)
+- [habitat_sup](https://docs.chef.io/resources/habitat_sup/)
+
 ## Description
 
 This cookbook provides resources for working with [Habitat](https://habitat.sh). It is intended that these resources will be included in core Chef at some point in the future, so it is important to note:

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -19,6 +19,8 @@ require 'json'
 resource_name :hab_config
 provides :hab_config
 
+unified_mode true if respond_to?(:unified_mode)
+
 property :config, Mash,
          required: true,
          coerce: proc { |m| m.is_a?(Hash) ? Mash.new(m) : m }

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -22,6 +22,8 @@ require 'chef/http/simple'
 resource_name :hab_install
 provides :hab_install
 
+unified_mode true if respond_to?(:unified_mode)
+
 property :name, String, default: ''
 # The following are only used on *nix
 property :install_url, String, default: 'https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -17,6 +17,8 @@
 resource_name :hab_service
 provides :hab_service
 
+unified_mode true if respond_to?(:unified_mode)
+
 property :service_name, String, name_property: true
 property :loaded, [true, false], default: false
 property :running, [true, false], default: false

--- a/resources/user_toml.rb
+++ b/resources/user_toml.rb
@@ -14,6 +14,8 @@
 resource_name :hab_user_toml
 provides :hab_user_toml
 
+unified_mode true if respond_to?(:unified_mode)
+
 property :config, Mash,
          required: true,
          coerce: proc { |m| m.is_a?(Hash) ? Mash.new(m) : m }


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
- Adds `unified_mode` statements to custom resources included within cookbook
- Adds an EOL notice to the README indicating where functionality has been updated to run with Chef Infra Client in version `17.3`


### Check List
- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>